### PR TITLE
USE_TORCH_COMPILE_IN_MAMBA_ATTN=1 to enable torch.compile for 2 native functions

### DIFF
--- a/python/sglang/srt/layers/attention/torch_native_hybrid_linear_attn_backend.py
+++ b/python/sglang/srt/layers/attention/torch_native_hybrid_linear_attn_backend.py
@@ -1,3 +1,4 @@
+import os
 from dataclasses import astuple, dataclass
 from functools import lru_cache
 from typing import Optional, Union
@@ -17,6 +18,8 @@ from sglang.srt.models.qwen3_next import Qwen3HybridLinearDecoderLayer
 from sglang.srt.speculative.eagle_utils import EagleDraftInput, EagleVerifyInput
 import sgl_kernel
 
+USE_COMPILE = os.environ.get("USE_TORCH_COMPILE_IN_MAMBA_ATTN", "0") == "1"
+
 @dataclass
 class ForwardMetadata:
     query_start_loc: Optional[torch.Tensor]
@@ -24,6 +27,11 @@ class ForwardMetadata:
 
 
 
+def maybe_compile(fn):
+    return torch.compile(fn) if USE_COMPILE else fn
+
+
+@maybe_compile
 def causal_conv1d_ref(
     x,
     weight,
@@ -165,6 +173,7 @@ def torch_chunk_gated_delta_rule(
     return core_attn_out, last_recurrent_state
 
 
+@maybe_compile
 def torch_recurrent_gated_delta_rule(
     query, key, value, g, beta, initial_state, output_final_state, use_qk_l2norm_in_kernel=False
 ):


### PR DESCRIPTION


<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

Add `export USE_TORCH_COMPILE_IN_MAMBA_ATTN=1` to use `torch.compile` for the below 2 functions to speedup prefill and decode:
```
causal_conv1d_ref
torch_recurrent_gated_delta_rule
```

