### PR TITLE
fused recurrent gated delta rule

### DIFF
--- a/python/sglang/srt/layers/attention/torch_native_hybrid_linear_attn_backend.py
+++ b/python/sglang/srt/layers/attention/torch_native_hybrid_linear_attn_backend.py
@@ -438,21 +438,16 @@ class MambaAttnBackend(AttentionBackend):
         beta = b.sigmoid()
         # g = torch_gdn_gating(A_log, a, dt_bias)
         g = self.fused_gdn_gating(A_log, a, dt_bias)
-        if num_value_heads // num_heads > 1:
-            query = query.repeat_interleave(num_value_heads // num_heads, dim=2)
-            key = key.repeat_interleave(num_value_heads // num_heads, dim=2)
-        batch_size = forward_batch.batch_size
-        core_attn_out, last_recurrent_state = torch_recurrent_gated_delta_rule(
-            query=query.transpose(0,1).view(batch_size, -1, *query.shape[2:]),
-            key=key.transpose(0,1).view(batch_size, -1, *key.shape[2:]),
-            value=value.transpose(0, 1).view(batch_size, -1, *value.shape[2:]),
-            g=g.unsqueeze(0),
-            beta=beta.unsqueeze(0),
-            initial_state=ssm_states[cache_indices],
-            output_final_state=True,
-            use_qk_l2norm_in_kernel=True,
+        core_attn_out = torch.ops.sgl_kernel.fused_recurrent_gated_delta_rule_cpu(
+            query,
+            key,
+            value,
+            g,
+            beta,
+            cache_indices,
+            ssm_states,
+            True,
         )
-        ssm_states[cache_indices] = last_recurrent_state.to(ssm_states.dtype, copy=False)
         return core_attn_out
 
     def forward_extend(

--- a/python/sglang/srt/layers/attention/torch_native_hybrid_linear_attn_backend.py
+++ b/python/sglang/srt/layers/attention/torch_native_hybrid_linear_attn_backend.py
@@ -435,15 +435,14 @@ class MambaAttnBackend(AttentionBackend):
         query = query.view(1, seq_len, num_heads, head_k_dim)
         key = key.view(1, seq_len, num_heads, head_k_dim)
         value = value.view(1, seq_len, num_value_heads, head_v_dim)
-        beta = b.sigmoid()
-        # g = torch_gdn_gating(A_log, a, dt_bias)
-        g = self.fused_gdn_gating(A_log, a, dt_bias)
-        core_attn_out = torch.ops.sgl_kernel.fused_recurrent_gated_delta_rule_cpu(
-            query,
-            key,
+        core_attn_out = torch.ops.sgl_kernel.fused_sigmoid_gating_delta_rule_update_cpu(
+            query.contiguous(),
+            key.contiguous(),
             value,
-            g,
-            beta,
+            A_log,
+            a,
+            dt_bias,
+            b,
             cache_indices,
             ssm_states,
             True,
@@ -545,15 +544,15 @@ class MambaAttnBackend(AttentionBackend):
         beta = beta.unsqueeze(0)
 
         if is_target_verify:
-            core_attn_out, last_recurrent_state = torch_recurrent_gated_delta_rule(
-                query=query,
-                key=key,
-                value=value,
-                g=g,
-                beta=beta,
-                initial_state=ssm_states[cache_indices],
-                output_final_state=False,
-                use_qk_l2norm_in_kernel=True,
+            core_attn_out = torch.ops.sgl_kernel.fused_recurrent_gated_delta_rule_cpu(
+                query,
+                key,
+                value,
+                g,
+                beta,
+                cache_indices,
+                ssm_states,
+                True,
             )
         else:
             recurrent_state = ssm_states[cache_indices]

--- a/sgl-kernel/csrc/cpu/mamba.cpp
+++ b/sgl-kernel/csrc/cpu/mamba.cpp
@@ -293,7 +293,16 @@ void fused_recurrent_gated_delta_rule_kernel_impl(
     int64_t num_heads,
     int64_t head_dim,
     int64_t v_num_heads,
-    int64_t v_head_dim) {
+    int64_t v_head_dim,
+    int64_t q_strideB,
+    int64_t q_strideS,
+    int64_t q_strideH,
+    int64_t k_strideB,
+    int64_t k_strideS,
+    int64_t k_strideH,
+    int64_t v_strideB,
+    int64_t v_strideS,
+    int64_t v_strideH) {
   using bVec = at::vec::Vectorized<scalar_t>;
   using fVec = at::vec::Vectorized<float>;
 
@@ -308,19 +317,20 @@ void fused_recurrent_gated_delta_rule_kernel_impl(
     for (int64_t i = begin; i < end; ++i) {
         int64_t cache_index = indices_ptr[bi];
         int64_t state_offset = (cache_index * v_num_heads + ni) * head_dim * v_head_dim;
-        float g_val = g_ptr[bi * v_num_heads + ni];
+        float g_val = g_ptr[ni];
         float g_val_exp = std::exp(g_val);
         fVec g_val_exp_vec = fVec(g_val_exp);
-        int64_t qk_offset = ((si * batch_size + bi) * num_heads + (ni / group_size)) * head_dim;
-        int64_t v_offset = ((si * batch_size + bi) * v_num_heads + ni) * v_head_dim;
+        int64_t q_offset = si * q_strideS + bi * q_strideB + (ni / group_size) * q_strideH;
+        int64_t k_offset = si * k_strideS + bi * k_strideB + (ni / group_size) * k_strideH;
+        int64_t v_offset = si * v_strideS + bi * v_strideB + ni * v_strideH;
         int64_t o_offset = ((bi * seq_len + si) * v_num_heads + ni) * v_head_dim;
         int64_t dt_kv_mem_offset = ((bi * seq_len + si) * v_num_heads + ni) * v_head_dim;
-        float beta_val = beta_ptr[bi * v_num_heads + ni];
+        float beta_val = beta_ptr[ni];
         fVec beta_vec = fVec(beta_val);
         int64_t dvi = 0;
         for (; dvi <= v_head_dim - fVecSize; dvi += fVecSize) {
           for (int di = 0; di < head_dim; ++di) {
-            fVec k_val_vec = fVec(k_ptr[qk_offset + di]);
+            fVec k_val_vec = fVec(k_ptr[k_offset + di]);
             fVec state_vec = fVec::loadu(state_ptr + state_offset + di * v_head_dim + dvi);
             fVec kv_mem_vec = fVec::loadu(kv_mem_ptr + dt_kv_mem_offset + dvi);
             state_vec = state_vec * g_val_exp_vec;
@@ -331,7 +341,7 @@ void fused_recurrent_gated_delta_rule_kernel_impl(
         }
         for(; dvi < v_head_dim; ++dvi) {
           for (int di = 0; di < head_dim; ++di) {
-            float k_val = k_ptr[qk_offset + di];
+            float k_val = k_ptr[k_offset + di];
             state_ptr[state_offset + di * v_head_dim + dvi] *= g_val_exp;
             kv_mem_ptr[dt_kv_mem_offset + dvi] += state_ptr[state_offset + di * v_head_dim + dvi] * k_val;
           }
@@ -348,8 +358,8 @@ void fused_recurrent_gated_delta_rule_kernel_impl(
           fVec o_vec0, o_vec1;
           std::tie(o_vec0, o_vec1) = at::vec::convert_to_float(o_vec);
           for (int di = 0; di < head_dim; ++di) {
-            fVec q_vec = fVec(q_ptr[qk_offset + di]);
-            fVec k_vec = fVec(k_ptr[qk_offset + di]);
+            fVec q_vec = fVec(q_ptr[q_offset + di]);
+            fVec k_vec = fVec(k_ptr[k_offset + di]);
             fVec state_vec0 = fVec::loadu(state_ptr + state_offset + di * v_head_dim + dvi);
             fVec state_vec1 = fVec::loadu(state_ptr + state_offset + di * v_head_dim + dvi + fVecSize);
             state_vec0 = state_vec0 + k_vec * dt_vec0;
@@ -367,15 +377,15 @@ void fused_recurrent_gated_delta_rule_kernel_impl(
           float dt_val = (v_val - kv_mem_ptr[dt_kv_mem_offset + dvi]) * beta_val;
           float o_val = o_ptr[o_offset + dvi];
           for (int di = 0; di < head_dim; ++di) {
-            float q_val = q_ptr[qk_offset + di];
-            float k_val = k_ptr[qk_offset + di];
+            float q_val = q_ptr[q_offset + di];
+            float k_val = k_ptr[k_offset + di];
             state_ptr[state_offset + di * v_head_dim + dvi] += k_val * dt_val;
             o_val += state_ptr[state_offset + di * v_head_dim + dvi] * q_val * scale;
           }
           o_ptr[o_offset + dvi] = o_val;
         }
+      data_index_step(bi, batch_size, si, seq_len, ni, v_num_heads);
     }
-    data_index_step(bi, batch_size, si, seq_len, ni, v_num_heads);
   });
 }
 
@@ -396,7 +406,16 @@ void fused_sigmoid_gating_delta_rule_update_kernel_impl(
     int64_t num_heads,
     int64_t head_dim,
     int64_t v_num_heads,
-    int64_t v_head_dim) {
+    int64_t v_head_dim,
+    int64_t q_strideB,
+    int64_t q_strideS,
+    int64_t q_strideH,
+    int64_t k_strideB,
+    int64_t k_strideS,
+    int64_t k_strideH,
+    int64_t v_strideB,
+    int64_t v_strideS,
+    int64_t v_strideH) {
   using bVec = at::vec::Vectorized<scalar_t>;
   using fVec = at::vec::Vectorized<float>;
 
@@ -411,19 +430,20 @@ void fused_sigmoid_gating_delta_rule_update_kernel_impl(
     for (int64_t i = begin; i < end; ++i) {
         int64_t cache_index = indices_ptr[bi];
         int64_t state_offset = (cache_index * v_num_heads + ni) * head_dim * v_head_dim;
-        float g_val = g_ptr[bi * v_num_heads + ni];
+        float g_val = g_ptr[ni];
         float g_val_exp = std::exp(g_val);
         fVec g_val_exp_vec = fVec(g_val_exp);
-        int64_t qk_offset = ((si * batch_size + bi) * num_heads + (ni / group_size)) * head_dim;
-        int64_t v_offset = ((si * batch_size + bi) * v_num_heads + ni) * v_head_dim;
+        int64_t q_offset = si * q_strideS + bi * q_strideB + (ni / group_size) * q_strideH;
+        int64_t k_offset = si * k_strideS + bi * k_strideB + (ni / group_size) * k_strideH;
+        int64_t v_offset = si * v_strideS + bi * v_strideB + ni * v_strideH;
         int64_t o_offset = ((bi * seq_len + si) * v_num_heads + ni) * v_head_dim;
         int64_t dt_kv_mem_offset = ((bi * seq_len + si) * v_num_heads + ni) * v_head_dim;
-        float beta_val = 1 / (1 + std::exp(-b_ptr[bi * v_num_heads + ni]));
+        float beta_val = 1 / (1 + std::exp(-b_ptr[ni]));
         fVec beta_vec = fVec(beta_val);
         int64_t dvi = 0;
         for (; dvi <= v_head_dim - fVecSize; dvi += fVecSize) {
           for (int di = 0; di < head_dim; ++di) {
-            fVec k_val_vec = fVec(k_ptr[qk_offset + di]);
+            fVec k_val_vec = fVec(k_ptr[k_offset + di]);
             fVec state_vec = fVec::loadu(state_ptr + state_offset + di * v_head_dim + dvi);
             fVec kv_mem_vec = fVec::loadu(kv_mem_ptr + dt_kv_mem_offset + dvi);
             state_vec = state_vec * g_val_exp_vec;
@@ -434,7 +454,7 @@ void fused_sigmoid_gating_delta_rule_update_kernel_impl(
         }
         for(; dvi < v_head_dim; ++dvi) {
           for (int di = 0; di < head_dim; ++di) {
-            float k_val = k_ptr[qk_offset + di];
+            float k_val = k_ptr[k_offset + di];
             state_ptr[state_offset + di * v_head_dim + dvi] *= g_val_exp;
             kv_mem_ptr[dt_kv_mem_offset + dvi] += state_ptr[state_offset + di * v_head_dim + dvi] * k_val;
           }
@@ -451,8 +471,8 @@ void fused_sigmoid_gating_delta_rule_update_kernel_impl(
           fVec o_vec0, o_vec1;
           std::tie(o_vec0, o_vec1) = at::vec::convert_to_float(o_vec);
           for (int di = 0; di < head_dim; ++di) {
-            fVec q_vec = fVec(q_ptr[qk_offset + di]);
-            fVec k_vec = fVec(k_ptr[qk_offset + di]);
+            fVec q_vec = fVec(q_ptr[q_offset + di]);
+            fVec k_vec = fVec(k_ptr[k_offset + di]);
             fVec state_vec0 = fVec::loadu(state_ptr + state_offset + di * v_head_dim + dvi);
             fVec state_vec1 = fVec::loadu(state_ptr + state_offset + di * v_head_dim + dvi + fVecSize);
             state_vec0 = state_vec0 + k_vec * dt_vec0;
@@ -470,15 +490,15 @@ void fused_sigmoid_gating_delta_rule_update_kernel_impl(
           float dt_val = (v_val - kv_mem_ptr[dt_kv_mem_offset + dvi]) * beta_val;
           float o_val = o_ptr[o_offset + dvi];
           for (int di = 0; di < head_dim; ++di) {
-            float q_val = q_ptr[qk_offset + di];
-            float k_val = k_ptr[qk_offset + di];
+            float q_val = q_ptr[q_offset + di];
+            float k_val = k_ptr[k_offset + di];
             state_ptr[state_offset + di * v_head_dim + dvi] += k_val * dt_val;
             o_val += state_ptr[state_offset + di * v_head_dim + dvi] * q_val * scale;
           }
           o_ptr[o_offset + dvi] = o_val;
         }
+      data_index_step(bi, batch_size, si, seq_len, ni, v_num_heads);
     }
-    data_index_step(bi, batch_size, si, seq_len, ni, v_num_heads);
   });
 }
 }  // anonymous namespace
@@ -619,9 +639,9 @@ at::Tensor fused_recurrent_gated_delta_rule_cpu(
   CHECK_DIM(2, g);
   CHECK_DIM(2, beta);
   CHECK_DIM(4, initial_state);
-  CHECK_CONTIGUOUS(query);
-  CHECK_CONTIGUOUS(key);
-  CHECK_CONTIGUOUS(value);
+  CHECK_LAST_DIM_CONTIGUOUS_INPUT(query);
+  CHECK_LAST_DIM_CONTIGUOUS_INPUT(key);
+  CHECK_LAST_DIM_CONTIGUOUS_INPUT(value);
   CHECK_CONTIGUOUS(g);
   CHECK_CONTIGUOUS(beta);
   CHECK_CONTIGUOUS(initial_state);
@@ -644,7 +664,7 @@ at::Tensor fused_recurrent_gated_delta_rule_cpu(
   CHECK_EQ(beta.size(0), batch_size);
   CHECK_EQ(beta.size(1), v_num_heads);
   CHECK_EQ(cache_indices.size(0), batch_size);
-  CHECK(initial_state.size(0) >= seq_len);
+  CHECK(initial_state.size(0) >= batch_size);
   CHECK_EQ(initial_state.size(1), v_num_heads);
   CHECK_EQ(initial_state.size(2), head_dim);
   CHECK_EQ(initial_state.size(3), v_head_dim);
@@ -658,6 +678,15 @@ at::Tensor fused_recurrent_gated_delta_rule_cpu(
     query_ = qwen3_next_l2norm_cpu(query_, 1e-6);
     key_ = qwen3_next_l2norm_cpu(key_, 1e-6);
   }
+  int64_t q_strideS = query_.stride(0);
+  int64_t q_strideB = query_.stride(1);
+  int64_t q_strideH = query_.stride(2);
+  int64_t k_strideS = key_.stride(0);
+  int64_t k_strideB = key_.stride(1);
+  int64_t k_strideH = key_.stride(2);
+  int64_t v_strideS = value.stride(0);
+  int64_t v_strideB = value.stride(1);
+  int64_t v_strideH = value.stride(2);
   AT_DISPATCH_REDUCED_FLOATING_TYPES(query.scalar_type(), "fused_recurrent_gated_delta_rule_kernel_impl", [&] {
     fused_recurrent_gated_delta_rule_kernel_impl<scalar_t>(
         query_.data_ptr<scalar_t>(),
@@ -674,7 +703,16 @@ at::Tensor fused_recurrent_gated_delta_rule_cpu(
         num_heads,
         head_dim,
         v_num_heads,
-        v_head_dim);
+        v_head_dim,
+        q_strideB,
+        q_strideS,
+        q_strideH,
+        k_strideB,
+        k_strideS,
+        k_strideH,
+        v_strideB,
+        v_strideS,
+        v_strideH);
   });
   return core_attn_out;
 }
@@ -685,9 +723,9 @@ at::Tensor fused_recurrent_gated_delta_rule_cpu(
 // key: [seq_len, batch_size, num_heads, head_dim]
 // value: [seq_len, batch_size, v_num_heads, v_head_dim]
 // A_log: [v_num_heads]
-// a: [seq_len, v_num_heads]
+// a: [batch_size, v_num_heads]
 // dt_bias: [v_num_heads]
-// b: [seq_len, v_num_heads]
+// b: [batch_size, v_num_heads]
 // cache_indices: [batch_size]
 // initial_state:[num_tokens, v_num_heads, head_dim, v_head_dim]
 at::Tensor fused_sigmoid_gating_delta_rule_update_cpu(
@@ -711,9 +749,9 @@ at::Tensor fused_sigmoid_gating_delta_rule_update_cpu(
   CHECK_DIM(1, dt_bias);
   CHECK_DIM(2, b);
   CHECK_DIM(4, initial_state);
-  CHECK_CONTIGUOUS(query);
-  CHECK_CONTIGUOUS(key);
-  CHECK_CONTIGUOUS(value);
+  CHECK_LAST_DIM_CONTIGUOUS_INPUT(query);
+  CHECK_LAST_DIM_CONTIGUOUS_INPUT(key);
+  CHECK_LAST_DIM_CONTIGUOUS_INPUT(value);
   CHECK_CONTIGUOUS(a);
   CHECK_CONTIGUOUS(b);
   CHECK_CONTIGUOUS(initial_state);
@@ -731,14 +769,14 @@ at::Tensor fused_sigmoid_gating_delta_rule_update_cpu(
   CHECK_EQ(value.size(1), batch_size);
   CHECK_EQ(value.size(2), v_num_heads);
   CHECK_EQ(value.size(3), v_head_dim);
-  CHECK_EQ(a.size(0), seq_len);
+  CHECK_EQ(a.size(0), batch_size);
   CHECK_EQ(a.size(1), v_num_heads);
   CHECK_EQ(dt_bias.size(0), v_num_heads);
-  CHECK_EQ(b.size(0), seq_len);
+  CHECK_EQ(b.size(0), batch_size);
   CHECK_EQ(b.size(1), v_num_heads);
   CHECK_EQ(A_log.size(0), v_num_heads);
   CHECK_EQ(cache_indices.size(0), batch_size);
-  CHECK(initial_state.size(0) >= seq_len);
+  CHECK(initial_state.size(0) >= batch_size);
   CHECK_EQ(initial_state.size(1), v_num_heads);
   CHECK_EQ(initial_state.size(2), head_dim);
   CHECK_EQ(initial_state.size(3), v_head_dim);
@@ -753,6 +791,15 @@ at::Tensor fused_sigmoid_gating_delta_rule_update_cpu(
     key_ = qwen3_next_l2norm_cpu(key_, 1e-6);
   }
   at::Tensor g = fused_gdn_gating_cpu(A_log, a, dt_bias);
+  int64_t q_strideB = query_.stride(1);
+  int64_t q_strideS = query_.stride(0);
+  int64_t q_strideH = query_.stride(2);
+  int64_t k_strideB = key_.stride(1);
+  int64_t k_strideS = key_.stride(0);
+  int64_t k_strideH = key_.stride(2);
+  int64_t v_strideB = value.stride(1);
+  int64_t v_strideS = value.stride(0);
+  int64_t v_strideH = value.stride(2);
   AT_DISPATCH_REDUCED_FLOATING_TYPES(query.scalar_type(), "fused_sigmoid_gating_delta_rule_update_kernel_impl", [&] {
     fused_sigmoid_gating_delta_rule_update_kernel_impl<scalar_t>(
         query_.data_ptr<scalar_t>(),
@@ -769,7 +816,16 @@ at::Tensor fused_sigmoid_gating_delta_rule_update_cpu(
         num_heads,
         head_dim,
         v_num_heads,
-        v_head_dim);
+        v_head_dim,
+        q_strideB,
+        q_strideS,
+        q_strideH,
+        k_strideB,
+        k_strideS,
+        k_strideH,
+        v_strideB,
+        v_strideS,
+        v_strideH);
   });
   return core_attn_out;
 }

--- a/sgl-kernel/csrc/cpu/mamba.cpp
+++ b/sgl-kernel/csrc/cpu/mamba.cpp
@@ -386,7 +386,7 @@ void fused_sigmoid_gating_delta_rule_update_kernel_impl(
     const scalar_t* __restrict__ k_ptr,
     const scalar_t* __restrict__ v_ptr,
     const float* __restrict__ g_ptr,
-    const scalar_t* __restrict__ beta_ptr,
+    const scalar_t* __restrict__ b_ptr,
     const int32_t* __restrict__ indices_ptr,
     float* __restrict__ state_ptr,
     scalar_t* __restrict__ o_ptr,
@@ -418,7 +418,7 @@ void fused_sigmoid_gating_delta_rule_update_kernel_impl(
         int64_t v_offset = ((si * batch_size + bi) * v_num_heads + ni) * v_head_dim;
         int64_t o_offset = ((bi * seq_len + si) * v_num_heads + ni) * v_head_dim;
         int64_t dt_kv_mem_offset = ((bi * seq_len + si) * v_num_heads + ni) * v_head_dim;
-        float beta_val = beta_ptr[bi * v_num_heads + ni];
+        float beta_val = 1 / (1 + std::exp(-b_ptr[bi * v_num_heads + ni]));
         fVec beta_vec = fVec(beta_val);
         int64_t dvi = 0;
         for (; dvi <= v_head_dim - fVecSize; dvi += fVecSize) {
@@ -753,14 +753,13 @@ at::Tensor fused_sigmoid_gating_delta_rule_update_cpu(
     key_ = qwen3_next_l2norm_cpu(key_, 1e-6);
   }
   at::Tensor g = fused_gdn_gating_cpu(A_log, a, dt_bias);
-  at::Tensor beta = at::sigmoid(b);
   AT_DISPATCH_REDUCED_FLOATING_TYPES(query.scalar_type(), "fused_sigmoid_gating_delta_rule_update_kernel_impl", [&] {
     fused_sigmoid_gating_delta_rule_update_kernel_impl<scalar_t>(
         query_.data_ptr<scalar_t>(),
         key_.data_ptr<scalar_t>(),
         value.data_ptr<scalar_t>(),
         g.data_ptr<float>(),
-        beta.data_ptr<scalar_t>(),
+        b.data_ptr<scalar_t>(),
         cache_indices.data_ptr<int32_t>(),
         initial_state.data_ptr<float>(),
         core_attn_out.data_ptr<scalar_t>(),

--- a/sgl-kernel/csrc/cpu/mamba.cpp
+++ b/sgl-kernel/csrc/cpu/mamba.cpp
@@ -287,6 +287,7 @@ void fused_recurrent_gated_delta_rule_kernel_impl(
     const int32_t* __restrict__ indices_ptr,
     float* __restrict__ state_ptr,
     scalar_t* __restrict__ o_ptr,
+    float* __restrict__ kv_mem_ptr,
     int64_t seq_len,
     int64_t batch_size,
     int64_t num_heads,
@@ -294,8 +295,14 @@ void fused_recurrent_gated_delta_rule_kernel_impl(
     int64_t v_num_heads,
     int64_t v_head_dim,
     bool use_qk_l2norm_in_kernel) {
+  using bVec = at::vec::Vectorized<scalar_t>;
+  using fVec = at::vec::Vectorized<float>;
+
+  constexpr int64_t VecSize = bVec::size();
+  constexpr int64_t fVecSize = fVec::size();
   int64_t group_size = v_num_heads / num_heads;
   double scale = 1 / std::sqrt(head_dim);
+  fVec scale_vec = fVec(scale);
   at::parallel_for(0, batch_size * seq_len * v_num_heads, 0, [&](int64_t begin, int64_t end) {
     int64_t bi{0}, si{0}, ni{0};
     data_index_init(begin, bi, batch_size, si, seq_len, ni, v_num_heads);
@@ -304,24 +311,66 @@ void fused_recurrent_gated_delta_rule_kernel_impl(
         int64_t state_offset = (cache_index * v_num_heads + ni) * head_dim * v_head_dim;
         float g_val = g_ptr[bi * v_num_heads + ni];
         float g_val_exp = std::exp(g_val);
+        fVec g_val_exp_vec = fVec(g_val_exp);
         int64_t qk_offset = ((si * batch_size + bi) * num_heads + (ni / group_size)) * head_dim;
         int64_t v_offset = ((si * batch_size + bi) * v_num_heads + ni) * v_head_dim;
         int64_t o_offset = ((bi * seq_len + si) * v_num_heads + ni) * v_head_dim;
+        int64_t dt_kv_mem_offset = ((bi * seq_len + si) * v_num_heads + ni) * v_head_dim;
         float beta_val = beta_ptr[bi * v_num_heads + ni];
-        for (int dvi = 0; dvi < v_head_dim; ++dvi) {
-          float kv_mem_val = 0.0;
-          float v_val = v_ptr[v_offset + dvi];
-          float o_val = o_ptr[o_offset + dvi];
+        fVec beta_vec = fVec(beta_val);
+        int64_t dvi = 0;
+        for (; dvi <= v_head_dim - fVecSize; dvi += fVecSize) {
+          for (int di = 0; di < head_dim; ++di) {
+            fVec k_val_vec = fVec(k_ptr[qk_offset + di]);
+            fVec state_vec = fVec::loadu(state_ptr + state_offset + di * v_head_dim + dvi);
+            fVec kv_mem_vec = fVec::loadu(kv_mem_ptr + dt_kv_mem_offset + dvi);
+            state_vec = state_vec * g_val_exp_vec;
+            kv_mem_vec = kv_mem_vec + state_vec * k_val_vec;
+            state_vec.store(state_ptr + state_offset + di * v_head_dim + dvi);
+            kv_mem_vec.store(kv_mem_ptr + dt_kv_mem_offset + dvi);
+          }
+        }
+        for(; dvi < v_head_dim; ++dvi) {
           for (int di = 0; di < head_dim; ++di) {
             float k_val = k_ptr[qk_offset + di];
             state_ptr[state_offset + di * v_head_dim + dvi] *= g_val_exp;
-            kv_mem_val += state_ptr[state_offset + di * v_head_dim + dvi] * k_val;
+            kv_mem_ptr[dt_kv_mem_offset + dvi] += state_ptr[state_offset + di * v_head_dim + dvi] * k_val;
           }
+        }
+        for (dvi = 0; dvi <= v_head_dim - VecSize; dvi += VecSize) {
+          bVec v_bvec = bVec::loadu(v_ptr + v_offset + dvi);
+          fVec v_vec0, v_vec1;
+          std::tie(v_vec0, v_vec1) = at::vec::convert_to_float(v_bvec);
+          fVec kv_mem_vec0 = fVec::loadu(kv_mem_ptr + dt_kv_mem_offset + dvi);
+          fVec kv_mem_vec1 = fVec::loadu(kv_mem_ptr + dt_kv_mem_offset + dvi + fVecSize);
+          fVec dt_vec0 = (v_vec0 - kv_mem_vec0) * beta_vec;
+          fVec dt_vec1 = (v_vec1 - kv_mem_vec1) * beta_vec;
+          bVec o_vec = bVec::loadu(o_ptr + o_offset + dvi);
+          fVec o_vec0, o_vec1;
+          std::tie(o_vec0, o_vec1) = at::vec::convert_to_float(o_vec);
+          for (int di = 0; di < head_dim; ++di) {
+            fVec q_vec = fVec(q_ptr[qk_offset + di]);
+            fVec k_vec = fVec(k_ptr[qk_offset + di]);
+            fVec state_vec0 = fVec::loadu(state_ptr + state_offset + di * v_head_dim + dvi);
+            fVec state_vec1 = fVec::loadu(state_ptr + state_offset + di * v_head_dim + dvi + fVecSize);
+            state_vec0 = state_vec0 + k_vec * dt_vec0;
+            state_vec1 = state_vec1 + k_vec * dt_vec1;
+            o_vec0 = o_vec0 + state_vec0 * q_vec * scale_vec;
+            o_vec1 = o_vec1 + state_vec1 * q_vec * scale_vec;
+            state_vec0.store(state_ptr + state_offset + di * v_head_dim + dvi);
+            state_vec1.store(state_ptr + state_offset + di * v_head_dim + dvi + fVecSize);
+          }
+          o_vec = at::vec::convert_from_float<scalar_t>(o_vec0, o_vec1);
+          o_vec.store(o_ptr + o_offset + dvi);
+        }
+        for (; dvi < v_head_dim; ++dvi) {
+          float v_val = v_ptr[v_offset + dvi];
+          float dt_val = (v_val - kv_mem_ptr[dt_kv_mem_offset + dvi]) * beta_val;
+          float o_val = o_ptr[o_offset + dvi];
           for (int di = 0; di < head_dim; ++di) {
             float q_val = q_ptr[qk_offset + di];
             float k_val = k_ptr[qk_offset + di];
-            float delta_val = (v_val - kv_mem_val) * beta_val;
-            state_ptr[state_offset + di * v_head_dim + dvi] += k_val * delta_val;
+            state_ptr[state_offset + di * v_head_dim + dvi] += k_val * dt_val;
             o_val += state_ptr[state_offset + di * v_head_dim + dvi] * q_val * scale;
           }
           o_ptr[o_offset + dvi] = o_val;
@@ -497,7 +546,7 @@ at::Tensor fused_recurrent_gated_delta_rule_cpu(
   CHECK_EQ(v_num_heads % num_heads, 0);
 
   at::Tensor core_attn_out = at::zeros({batch_size, seq_len, v_num_heads, v_head_dim}, at::kBFloat16);
- 
+  at::Tensor kv_mem = at::zeros({batch_size, seq_len, v_num_heads, v_head_dim}, at::kFloat);
   AT_DISPATCH_REDUCED_FLOATING_TYPES(query.scalar_type(), "fused_recurrent_gated_delta_rule_kernel_impl", [&] {
     fused_recurrent_gated_delta_rule_kernel_impl<scalar_t>(
         query.data_ptr<scalar_t>(),
@@ -508,6 +557,7 @@ at::Tensor fused_recurrent_gated_delta_rule_cpu(
         cache_indices.data_ptr<int32_t>(),
         initial_state.data_ptr<float>(),
         core_attn_out.data_ptr<scalar_t>(),
+        kv_mem.data_ptr<float>(),
         seq_len,
         batch_size,
         num_heads,

--- a/sgl-kernel/csrc/cpu/mamba.cpp
+++ b/sgl-kernel/csrc/cpu/mamba.cpp
@@ -378,6 +378,109 @@ void fused_recurrent_gated_delta_rule_kernel_impl(
     data_index_step(bi, batch_size, si, seq_len, ni, v_num_heads);
   });
 }
+
+
+template <typename scalar_t>
+void fused_sigmoid_gating_delta_rule_update_kernel_impl(
+    const scalar_t* __restrict__ q_ptr,
+    const scalar_t* __restrict__ k_ptr,
+    const scalar_t* __restrict__ v_ptr,
+    const float* __restrict__ g_ptr,
+    const scalar_t* __restrict__ beta_ptr,
+    const int32_t* __restrict__ indices_ptr,
+    float* __restrict__ state_ptr,
+    scalar_t* __restrict__ o_ptr,
+    float* __restrict__ kv_mem_ptr,
+    int64_t seq_len,
+    int64_t batch_size,
+    int64_t num_heads,
+    int64_t head_dim,
+    int64_t v_num_heads,
+    int64_t v_head_dim) {
+  using bVec = at::vec::Vectorized<scalar_t>;
+  using fVec = at::vec::Vectorized<float>;
+
+  constexpr int64_t VecSize = bVec::size();
+  constexpr int64_t fVecSize = fVec::size();
+  int64_t group_size = v_num_heads / num_heads;
+  double scale = 1 / std::sqrt(head_dim);
+  fVec scale_vec = fVec(scale);
+  at::parallel_for(0, batch_size * seq_len * v_num_heads, 0, [&](int64_t begin, int64_t end) {
+    int64_t bi{0}, si{0}, ni{0};
+    data_index_init(begin, bi, batch_size, si, seq_len, ni, v_num_heads);
+    for (int64_t i = begin; i < end; ++i) {
+        int64_t cache_index = indices_ptr[bi];
+        int64_t state_offset = (cache_index * v_num_heads + ni) * head_dim * v_head_dim;
+        float g_val = g_ptr[bi * v_num_heads + ni];
+        float g_val_exp = std::exp(g_val);
+        fVec g_val_exp_vec = fVec(g_val_exp);
+        int64_t qk_offset = ((si * batch_size + bi) * num_heads + (ni / group_size)) * head_dim;
+        int64_t v_offset = ((si * batch_size + bi) * v_num_heads + ni) * v_head_dim;
+        int64_t o_offset = ((bi * seq_len + si) * v_num_heads + ni) * v_head_dim;
+        int64_t dt_kv_mem_offset = ((bi * seq_len + si) * v_num_heads + ni) * v_head_dim;
+        float beta_val = beta_ptr[bi * v_num_heads + ni];
+        fVec beta_vec = fVec(beta_val);
+        int64_t dvi = 0;
+        for (; dvi <= v_head_dim - fVecSize; dvi += fVecSize) {
+          for (int di = 0; di < head_dim; ++di) {
+            fVec k_val_vec = fVec(k_ptr[qk_offset + di]);
+            fVec state_vec = fVec::loadu(state_ptr + state_offset + di * v_head_dim + dvi);
+            fVec kv_mem_vec = fVec::loadu(kv_mem_ptr + dt_kv_mem_offset + dvi);
+            state_vec = state_vec * g_val_exp_vec;
+            kv_mem_vec = kv_mem_vec + state_vec * k_val_vec;
+            state_vec.store(state_ptr + state_offset + di * v_head_dim + dvi);
+            kv_mem_vec.store(kv_mem_ptr + dt_kv_mem_offset + dvi);
+          }
+        }
+        for(; dvi < v_head_dim; ++dvi) {
+          for (int di = 0; di < head_dim; ++di) {
+            float k_val = k_ptr[qk_offset + di];
+            state_ptr[state_offset + di * v_head_dim + dvi] *= g_val_exp;
+            kv_mem_ptr[dt_kv_mem_offset + dvi] += state_ptr[state_offset + di * v_head_dim + dvi] * k_val;
+          }
+        }
+        for (dvi = 0; dvi <= v_head_dim - VecSize; dvi += VecSize) {
+          bVec v_bvec = bVec::loadu(v_ptr + v_offset + dvi);
+          fVec v_vec0, v_vec1;
+          std::tie(v_vec0, v_vec1) = at::vec::convert_to_float(v_bvec);
+          fVec kv_mem_vec0 = fVec::loadu(kv_mem_ptr + dt_kv_mem_offset + dvi);
+          fVec kv_mem_vec1 = fVec::loadu(kv_mem_ptr + dt_kv_mem_offset + dvi + fVecSize);
+          fVec dt_vec0 = (v_vec0 - kv_mem_vec0) * beta_vec;
+          fVec dt_vec1 = (v_vec1 - kv_mem_vec1) * beta_vec;
+          bVec o_vec = bVec::loadu(o_ptr + o_offset + dvi);
+          fVec o_vec0, o_vec1;
+          std::tie(o_vec0, o_vec1) = at::vec::convert_to_float(o_vec);
+          for (int di = 0; di < head_dim; ++di) {
+            fVec q_vec = fVec(q_ptr[qk_offset + di]);
+            fVec k_vec = fVec(k_ptr[qk_offset + di]);
+            fVec state_vec0 = fVec::loadu(state_ptr + state_offset + di * v_head_dim + dvi);
+            fVec state_vec1 = fVec::loadu(state_ptr + state_offset + di * v_head_dim + dvi + fVecSize);
+            state_vec0 = state_vec0 + k_vec * dt_vec0;
+            state_vec1 = state_vec1 + k_vec * dt_vec1;
+            o_vec0 = o_vec0 + state_vec0 * q_vec * scale_vec;
+            o_vec1 = o_vec1 + state_vec1 * q_vec * scale_vec;
+            state_vec0.store(state_ptr + state_offset + di * v_head_dim + dvi);
+            state_vec1.store(state_ptr + state_offset + di * v_head_dim + dvi + fVecSize);
+          }
+          o_vec = at::vec::convert_from_float<scalar_t>(o_vec0, o_vec1);
+          o_vec.store(o_ptr + o_offset + dvi);
+        }
+        for (; dvi < v_head_dim; ++dvi) {
+          float v_val = v_ptr[v_offset + dvi];
+          float dt_val = (v_val - kv_mem_ptr[dt_kv_mem_offset + dvi]) * beta_val;
+          float o_val = o_ptr[o_offset + dvi];
+          for (int di = 0; di < head_dim; ++di) {
+            float q_val = q_ptr[qk_offset + di];
+            float k_val = k_ptr[qk_offset + di];
+            state_ptr[state_offset + di * v_head_dim + dvi] += k_val * dt_val;
+            o_val += state_ptr[state_offset + di * v_head_dim + dvi] * q_val * scale;
+          }
+          o_ptr[o_offset + dvi] = o_val;
+        }
+    }
+    data_index_step(bi, batch_size, si, seq_len, ni, v_num_heads);
+  });
+}
 }  // anonymous namespace
 
 extern at::Tensor qwen3_next_l2norm_cpu(at::Tensor& input, double eps);
@@ -387,7 +490,7 @@ extern at::Tensor qwen3_next_l2norm_cpu(at::Tensor& input, double eps);
 // a: [batch, num_v_heads]
 // dt_bias: [num_v_heads]
 // -A_log.float().exp() * F.softplus(a.float() + dt_bias)
-at::Tensor fused_gdn_gating_cpu(at::Tensor& A_log, at::Tensor& a, at::Tensor& dt_bias) {
+at::Tensor fused_gdn_gating_cpu(const at::Tensor& A_log, const at::Tensor& a, const at::Tensor& dt_bias) {
   RECORD_FUNCTION("sgl-kernel::fused_gdn_gating_cpu", std::vector<c10::IValue>({A_log, a, dt_bias}));
   CHECK_DIM(1, A_log);
   CHECK_DIM(2, a);
@@ -557,6 +660,102 @@ at::Tensor fused_recurrent_gated_delta_rule_cpu(
   }
   AT_DISPATCH_REDUCED_FLOATING_TYPES(query.scalar_type(), "fused_recurrent_gated_delta_rule_kernel_impl", [&] {
     fused_recurrent_gated_delta_rule_kernel_impl<scalar_t>(
+        query_.data_ptr<scalar_t>(),
+        key_.data_ptr<scalar_t>(),
+        value.data_ptr<scalar_t>(),
+        g.data_ptr<float>(),
+        beta.data_ptr<scalar_t>(),
+        cache_indices.data_ptr<int32_t>(),
+        initial_state.data_ptr<float>(),
+        core_attn_out.data_ptr<scalar_t>(),
+        kv_mem.data_ptr<float>(),
+        seq_len,
+        batch_size,
+        num_heads,
+        head_dim,
+        v_num_heads,
+        v_head_dim);
+  });
+  return core_attn_out;
+}
+
+
+
+// query: [seq_len, batch_size, num_heads, head_dim]
+// key: [seq_len, batch_size, num_heads, head_dim]
+// value: [seq_len, batch_size, v_num_heads, v_head_dim]
+// A_log: [v_num_heads]
+// a: [seq_len, v_num_heads]
+// dt_bias: [v_num_heads]
+// b: [seq_len, v_num_heads]
+// cache_indices: [batch_size]
+// initial_state:[num_tokens, v_num_heads, head_dim, v_head_dim]
+at::Tensor fused_sigmoid_gating_delta_rule_update_cpu(
+  const at::Tensor& query,
+  const at::Tensor& key,
+  const at::Tensor& value,
+  const at::Tensor& A_log,
+  const at::Tensor& a,
+  const at::Tensor& dt_bias,
+  const at::Tensor& b,
+  const at::Tensor& cache_indices,
+  at::Tensor& initial_state,
+  bool use_qk_l2norm_in_kernel
+) {
+  RECORD_FUNCTION("sgl-kernel::fused_sigmoid_gating_delta_rule_update_cpu", std::vector<c10::IValue>({query, key, value, A_log, a, dt_bias, b, initial_state}));
+  CHECK_DIM(4, query);
+  CHECK_DIM(4, key);
+  CHECK_DIM(4, value);
+  CHECK_DIM(1, A_log);
+  CHECK_DIM(2, a);
+  CHECK_DIM(1, dt_bias);
+  CHECK_DIM(2, b);
+  CHECK_DIM(4, initial_state);
+  CHECK_CONTIGUOUS(query);
+  CHECK_CONTIGUOUS(key);
+  CHECK_CONTIGUOUS(value);
+  CHECK_CONTIGUOUS(a);
+  CHECK_CONTIGUOUS(b);
+  CHECK_CONTIGUOUS(initial_state);
+  int64_t seq_len = query.size(0);
+  int64_t batch_size = query.size(1);
+  int64_t num_heads = query.size(2);
+  int64_t head_dim = query.size(3);
+  int64_t v_num_heads = value.size(2);
+  int64_t v_head_dim = value.size(3);
+  CHECK_EQ(key.size(0), seq_len);
+  CHECK_EQ(key.size(1), batch_size);
+  CHECK_EQ(key.size(2), num_heads);
+  CHECK_EQ(key.size(3), head_dim);
+  CHECK_EQ(value.size(0), seq_len);
+  CHECK_EQ(value.size(1), batch_size);
+  CHECK_EQ(value.size(2), v_num_heads);
+  CHECK_EQ(value.size(3), v_head_dim);
+  CHECK_EQ(a.size(0), seq_len);
+  CHECK_EQ(a.size(1), v_num_heads);
+  CHECK_EQ(dt_bias.size(0), v_num_heads);
+  CHECK_EQ(b.size(0), seq_len);
+  CHECK_EQ(b.size(1), v_num_heads);
+  CHECK_EQ(A_log.size(0), v_num_heads);
+  CHECK_EQ(cache_indices.size(0), batch_size);
+  CHECK(initial_state.size(0) >= seq_len);
+  CHECK_EQ(initial_state.size(1), v_num_heads);
+  CHECK_EQ(initial_state.size(2), head_dim);
+  CHECK_EQ(initial_state.size(3), v_head_dim);
+  CHECK_EQ(v_num_heads % num_heads, 0);
+
+  at::Tensor core_attn_out = at::zeros({batch_size, seq_len, v_num_heads, v_head_dim}, at::kBFloat16);
+  at::Tensor kv_mem = at::zeros({batch_size, seq_len, v_num_heads, v_head_dim}, at::kFloat);
+  at::Tensor query_ = query;
+  at::Tensor key_ = key;
+  if (use_qk_l2norm_in_kernel) {
+    query_ = qwen3_next_l2norm_cpu(query_, 1e-6);
+    key_ = qwen3_next_l2norm_cpu(key_, 1e-6);
+  }
+  at::Tensor g = fused_gdn_gating_cpu(A_log, a, dt_bias);
+  at::Tensor beta = at::sigmoid(b);
+  AT_DISPATCH_REDUCED_FLOATING_TYPES(query.scalar_type(), "fused_sigmoid_gating_delta_rule_update_kernel_impl", [&] {
+    fused_sigmoid_gating_delta_rule_update_kernel_impl<scalar_t>(
         query_.data_ptr<scalar_t>(),
         key_.data_ptr<scalar_t>(),
         value.data_ptr<scalar_t>(),

--- a/sgl-kernel/csrc/cpu/mamba.cpp
+++ b/sgl-kernel/csrc/cpu/mamba.cpp
@@ -296,12 +296,14 @@ void fused_recurrent_gated_delta_rule_kernel_impl(
     bool use_qk_l2norm_in_kernel) {
   int64_t group_size = v_num_heads / num_heads;
   double scale = 1 / std::sqrt(head_dim);
-  for (int bi = 0; bi < batch_size; ++bi) {
-    for(int si = 0; si < seq_len; ++si) {
-      for(int ni = 0; ni < v_num_heads; ++ni) {
+  at::parallel_for(0, batch_size * seq_len * v_num_heads, 0, [&](int64_t begin, int64_t end) {
+    int64_t bi{0}, si{0}, ni{0};
+    data_index_init(begin, bi, batch_size, si, seq_len, ni, v_num_heads);
+    for (int64_t i = begin; i < end; ++i) {
         int64_t cache_index = indices_ptr[bi];
         int64_t state_offset = (cache_index * v_num_heads + ni) * head_dim * v_head_dim;
         float g_val = g_ptr[bi * v_num_heads + ni];
+        float g_val_exp = std::exp(g_val);
         int64_t qk_offset = ((si * batch_size + bi) * num_heads + (ni / group_size)) * head_dim;
         int64_t v_offset = ((si * batch_size + bi) * v_num_heads + ni) * v_head_dim;
         int64_t o_offset = ((bi * seq_len + si) * v_num_heads + ni) * v_head_dim;
@@ -312,7 +314,7 @@ void fused_recurrent_gated_delta_rule_kernel_impl(
           float o_val = o_ptr[o_offset + dvi];
           for (int di = 0; di < head_dim; ++di) {
             float k_val = k_ptr[qk_offset + di];
-            state_ptr[state_offset + di * v_head_dim + dvi] *= std::exp(g_val);
+            state_ptr[state_offset + di * v_head_dim + dvi] *= g_val_exp;
             kv_mem_val += state_ptr[state_offset + di * v_head_dim + dvi] * k_val;
           }
           for (int di = 0; di < head_dim; ++di) {
@@ -324,9 +326,9 @@ void fused_recurrent_gated_delta_rule_kernel_impl(
           }
           o_ptr[o_offset + dvi] = o_val;
         }
-      }
     }
-  }
+    data_index_step(bi, batch_size, si, seq_len, ni, v_num_heads);
+  });
 }
 }  // anonymous namespace
 

--- a/sgl-kernel/csrc/cpu/mamba.cpp
+++ b/sgl-kernel/csrc/cpu/mamba.cpp
@@ -293,8 +293,7 @@ void fused_recurrent_gated_delta_rule_kernel_impl(
     int64_t num_heads,
     int64_t head_dim,
     int64_t v_num_heads,
-    int64_t v_head_dim,
-    bool use_qk_l2norm_in_kernel) {
+    int64_t v_head_dim) {
   using bVec = at::vec::Vectorized<scalar_t>;
   using fVec = at::vec::Vectorized<float>;
 
@@ -380,6 +379,9 @@ void fused_recurrent_gated_delta_rule_kernel_impl(
   });
 }
 }  // anonymous namespace
+
+extern at::Tensor qwen3_next_l2norm_cpu(at::Tensor& input, double eps);
+
 
 // A_log: [num_v_heads]
 // a: [batch, num_v_heads]
@@ -547,10 +549,16 @@ at::Tensor fused_recurrent_gated_delta_rule_cpu(
 
   at::Tensor core_attn_out = at::zeros({batch_size, seq_len, v_num_heads, v_head_dim}, at::kBFloat16);
   at::Tensor kv_mem = at::zeros({batch_size, seq_len, v_num_heads, v_head_dim}, at::kFloat);
+  at::Tensor query_ = query;
+  at::Tensor key_ = key;
+  if (use_qk_l2norm_in_kernel) {
+    query_ = qwen3_next_l2norm_cpu(query_, 1e-6);
+    key_ = qwen3_next_l2norm_cpu(key_, 1e-6);
+  }
   AT_DISPATCH_REDUCED_FLOATING_TYPES(query.scalar_type(), "fused_recurrent_gated_delta_rule_kernel_impl", [&] {
     fused_recurrent_gated_delta_rule_kernel_impl<scalar_t>(
-        query.data_ptr<scalar_t>(),
-        key.data_ptr<scalar_t>(),
+        query_.data_ptr<scalar_t>(),
+        key_.data_ptr<scalar_t>(),
         value.data_ptr<scalar_t>(),
         g.data_ptr<float>(),
         beta.data_ptr<scalar_t>(),
@@ -563,8 +571,7 @@ at::Tensor fused_recurrent_gated_delta_rule_cpu(
         num_heads,
         head_dim,
         v_num_heads,
-        v_head_dim,
-        use_qk_l2norm_in_kernel);
+        v_head_dim);
   });
   return core_attn_out;
 }

--- a/sgl-kernel/csrc/cpu/mamba.cpp
+++ b/sgl-kernel/csrc/cpu/mamba.cpp
@@ -276,6 +276,58 @@ std::tuple<at::Tensor, at::Tensor> causal_conv1d_fn_kernel_inner(
   }
   return std::make_tuple(std::move(out), std::move(final_states_out));
 }
+
+template <typename scalar_t>
+void fused_recurrent_gated_delta_rule_kernel_impl(
+    const scalar_t* __restrict__ q_ptr,
+    const scalar_t* __restrict__ k_ptr,
+    const scalar_t* __restrict__ v_ptr,
+    const float* __restrict__ g_ptr,
+    const scalar_t* __restrict__ beta_ptr,
+    const int32_t* __restrict__ indices_ptr,
+    float* __restrict__ state_ptr,
+    scalar_t* __restrict__ o_ptr,
+    int64_t seq_len,
+    int64_t batch_size,
+    int64_t num_heads,
+    int64_t head_dim,
+    int64_t v_num_heads,
+    int64_t v_head_dim,
+    bool use_qk_l2norm_in_kernel) {
+  int64_t group_size = v_num_heads / num_heads;
+  double scale = 1 / std::sqrt(head_dim);
+  for (int bi = 0; bi < batch_size; ++bi) {
+    for(int si = 0; si < seq_len; ++si) {
+      for(int ni = 0; ni < v_num_heads; ++ni) {
+        int64_t cache_index = indices_ptr[bi];
+        int64_t state_offset = (cache_index * v_num_heads + ni) * head_dim * v_head_dim;
+        float g_val = g_ptr[bi * v_num_heads + ni];
+        int64_t qk_offset = ((si * batch_size + bi) * num_heads + (ni / group_size)) * head_dim;
+        int64_t v_offset = ((si * batch_size + bi) * v_num_heads + ni) * v_head_dim;
+        int64_t o_offset = ((bi * seq_len + si) * v_num_heads + ni) * v_head_dim;
+        float beta_val = beta_ptr[bi * v_num_heads + ni];
+        for (int dvi = 0; dvi < v_head_dim; ++dvi) {
+          float kv_mem_val = 0.0;
+          float v_val = v_ptr[v_offset + dvi];
+          float o_val = o_ptr[o_offset + dvi];
+          for (int di = 0; di < head_dim; ++di) {
+            float k_val = k_ptr[qk_offset + di];
+            state_ptr[state_offset + di * v_head_dim + dvi] *= std::exp(g_val);
+            kv_mem_val += state_ptr[state_offset + di * v_head_dim + dvi] * k_val;
+          }
+          for (int di = 0; di < head_dim; ++di) {
+            float q_val = q_ptr[qk_offset + di];
+            float k_val = k_ptr[qk_offset + di];
+            float delta_val = (v_val - kv_mem_val) * beta_val;
+            state_ptr[state_offset + di * v_head_dim + dvi] += k_val * delta_val;
+            o_val += state_ptr[state_offset + di * v_head_dim + dvi] * q_val * scale;
+          }
+          o_ptr[o_offset + dvi] = o_val;
+        }
+      }
+    }
+  }
+}
 }  // anonymous namespace
 
 // A_log: [num_v_heads]
@@ -385,4 +437,82 @@ std::tuple<at::Tensor, at::Tensor> causal_conv1d_fn_cpu(
     TORCH_CHECK(
         false, "Only support bfloat16, float16 and float for causal_conv1d_fn");
   }
+}
+
+// query: [seq_len, batch_size, num_heads, head_dim]
+// key: [seq_len, batch_size, num_heads, head_dim]
+// value: [seq_len, batch_size, v_num_heads, v_head_dim]
+// g: [batch_size, v_num_heads]
+// beta: [batch_size, v_num_heads]
+// cache_indices: [batch_size]
+// initial_state:[num_tokens, v_num_heads, head_dim, v_head_dim]
+at::Tensor fused_recurrent_gated_delta_rule_cpu(
+  const at::Tensor& query,
+  const at::Tensor& key,
+  const at::Tensor& value,
+  const at::Tensor& g,
+  const at::Tensor& beta,
+  const at::Tensor& cache_indices,
+  at::Tensor& initial_state,
+  bool use_qk_l2norm_in_kernel
+) {
+  RECORD_FUNCTION("sgl-kernel::fused_recurrent_gated_delta_rule_cpu", std::vector<c10::IValue>({query, key, value, g, beta, initial_state}));
+  CHECK_DIM(4, query);
+  CHECK_DIM(4, key);
+  CHECK_DIM(4, value);
+  CHECK_DIM(2, g);
+  CHECK_DIM(2, beta);
+  CHECK_DIM(4, initial_state);
+  CHECK_CONTIGUOUS(query);
+  CHECK_CONTIGUOUS(key);
+  CHECK_CONTIGUOUS(value);
+  CHECK_CONTIGUOUS(g);
+  CHECK_CONTIGUOUS(beta);
+  CHECK_CONTIGUOUS(initial_state);
+  int64_t seq_len = query.size(0);
+  int64_t batch_size = query.size(1);
+  int64_t num_heads = query.size(2);
+  int64_t head_dim = query.size(3);
+  int64_t v_num_heads = value.size(2);
+  int64_t v_head_dim = value.size(3);
+  CHECK_EQ(key.size(0), seq_len);
+  CHECK_EQ(key.size(1), batch_size);
+  CHECK_EQ(key.size(2), num_heads);
+  CHECK_EQ(key.size(3), head_dim);
+  CHECK_EQ(value.size(0), seq_len);
+  CHECK_EQ(value.size(1), batch_size);
+  CHECK_EQ(value.size(2), v_num_heads);
+  CHECK_EQ(value.size(3), v_head_dim);
+  CHECK_EQ(g.size(0), batch_size);
+  CHECK_EQ(g.size(1), v_num_heads);
+  CHECK_EQ(beta.size(0), batch_size);
+  CHECK_EQ(beta.size(1), v_num_heads);
+  CHECK_EQ(cache_indices.size(0), batch_size);
+  CHECK(initial_state.size(0) >= seq_len);
+  CHECK_EQ(initial_state.size(1), v_num_heads);
+  CHECK_EQ(initial_state.size(2), head_dim);
+  CHECK_EQ(initial_state.size(3), v_head_dim);
+  CHECK_EQ(v_num_heads % num_heads, 0);
+
+  at::Tensor core_attn_out = at::zeros({batch_size, seq_len, v_num_heads, v_head_dim}, at::kBFloat16);
+ 
+  AT_DISPATCH_REDUCED_FLOATING_TYPES(query.scalar_type(), "fused_recurrent_gated_delta_rule_kernel_impl", [&] {
+    fused_recurrent_gated_delta_rule_kernel_impl<scalar_t>(
+        query.data_ptr<scalar_t>(),
+        key.data_ptr<scalar_t>(),
+        value.data_ptr<scalar_t>(),
+        g.data_ptr<float>(),
+        beta.data_ptr<scalar_t>(),
+        cache_indices.data_ptr<int32_t>(),
+        initial_state.data_ptr<float>(),
+        core_attn_out.data_ptr<scalar_t>(),
+        seq_len,
+        batch_size,
+        num_heads,
+        head_dim,
+        v_num_heads,
+        v_head_dim,
+        use_qk_l2norm_in_kernel);
+  });
+  return core_attn_out;
 }

--- a/sgl-kernel/csrc/cpu/norm.cpp
+++ b/sgl-kernel/csrc/cpu/norm.cpp
@@ -5,12 +5,13 @@ namespace {
 
 // NB: avoid using `at::vec::map<>` on bfloat16 or half
 // Llama4TextL2Norm
-template <typename scalar_t>
+template <typename scalar_t, typename func_t>
 void l2norm_kernel_impl(
     scalar_t* __restrict__ output,
     const scalar_t* __restrict__ input,
     int64_t batch_size,
     int64_t hidden_size,
+    const func_t& f,
     float eps = 1e-5) {
   using bVec = at::vec::Vectorized<scalar_t>;
   using fVec = at::vec::Vectorized<float>;
@@ -42,7 +43,7 @@ void l2norm_kernel_impl(
       }
 
       sum_val += vec_reduce_sum(sum_fvec);
-      float rsqrt_var = float(1) / std::sqrt(sum_val / hidden_size + eps);
+      float rsqrt_var = float(1) / std::sqrt(f(sum_val, hidden_size) + eps);
       const fVec scale_fvec = fVec(rsqrt_var);
 
 #pragma GCC unroll 4
@@ -471,7 +472,13 @@ at::Tensor l2norm_cpu(at::Tensor& input, double eps) {
   at::Tensor output = at::empty_like(input);
 
   AT_DISPATCH_REDUCED_FLOATING_TYPES(input.scalar_type(), "l2norm_kernel", [&] {
-    l2norm_kernel_impl<scalar_t>(output.data_ptr<scalar_t>(), input.data_ptr<scalar_t>(), batch_size, hidden_size, eps);
+    l2norm_kernel_impl<scalar_t>(
+      output.data_ptr<scalar_t>(),
+      input.data_ptr<scalar_t>(),
+      batch_size,
+      hidden_size,
+      [](float x, int64_t n) { return x / n;},
+      eps);
   });
   return output;
 }

--- a/sgl-kernel/csrc/cpu/norm.cpp
+++ b/sgl-kernel/csrc/cpu/norm.cpp
@@ -488,8 +488,7 @@ at::Tensor l2norm_cpu(at::Tensor& input, double eps) {
 at::Tensor qwen3_next_l2norm_cpu(at::Tensor& input, double eps) {
   RECORD_FUNCTION("sgl-kernel::qwen3_next_l2norm_cpu", std::vector<c10::IValue>({input}));
 
-  CHECK_INPUT(input);
-  CHECK_CONTIGUOUS(input);
+  CHECK_LAST_DIM_CONTIGUOUS_INPUT(input);
   TORCH_CHECK(input.dim() == 2 || input.dim() == 4, "qwen3_next_l2norm_cpu: input must be 2D or 4D, got ", input.dim(), "D");
   int64_t numel = input.numel();
   int64_t hidden_size = input.size(-1);

--- a/sgl-kernel/csrc/cpu/norm.cpp
+++ b/sgl-kernel/csrc/cpu/norm.cpp
@@ -483,6 +483,32 @@ at::Tensor l2norm_cpu(at::Tensor& input, double eps) {
   return output;
 }
 
+
+// input : {batch_size, hidden_size} or {batch_size, seq_len, num_head, head_dim}
+at::Tensor qwen3_next_l2norm_cpu(at::Tensor& input, double eps) {
+  RECORD_FUNCTION("sgl-kernel::qwen3_next_l2norm_cpu", std::vector<c10::IValue>({input}));
+
+  CHECK_INPUT(input);
+  CHECK_CONTIGUOUS(input);
+  TORCH_CHECK(input.dim() == 2 || input.dim() == 4, "qwen3_next_l2norm_cpu: input must be 2D or 4D, got ", input.dim(), "D");
+  int64_t numel = input.numel();
+  int64_t hidden_size = input.size(-1);
+  int64_t batch_size = numel / hidden_size;
+  at::Tensor output = at::empty_like(input);
+
+  AT_DISPATCH_REDUCED_FLOATING_TYPES(input.scalar_type(), "l2norm_kernel", [&] {
+    l2norm_kernel_impl<scalar_t>(
+      output.data_ptr<scalar_t>(),
+      input.data_ptr<scalar_t>(),
+      batch_size,
+      hidden_size,
+      [](float x, int64_t n) { return x;},
+      eps);
+  });
+  return output;
+}
+
+
 // input : {batch_size, hidden_size}
 // weight: {hidden_size}
 at::Tensor rmsnorm_cpu(at::Tensor& input, at::Tensor& weight, double eps) {

--- a/sgl-kernel/csrc/cpu/torch_extension_cpu.cpp
+++ b/sgl-kernel/csrc/cpu/torch_extension_cpu.cpp
@@ -237,6 +237,17 @@ std::tuple<at::Tensor, at::Tensor> rotary_embedding_cpu(
 
 // fused_gdn_gating
 at::Tensor fused_gdn_gating_cpu(at::Tensor& A_log, at::Tensor& a, at::Tensor& dt_bias);
+// fused_recurrent_gated_delta_rule
+at::Tensor fused_recurrent_gated_delta_rule_cpu(
+  const at::Tensor& query,
+  const at::Tensor& key,
+  const at::Tensor& value,
+  const at::Tensor& g,
+  const at::Tensor& beta,
+  const at::Tensor& cache_indices,
+  at::Tensor& initial_state,
+  bool use_qk_l2norm_in_kernel
+);
 
 // CPU and memory binding
 std::string init_cpu_threads_env(const std::string& cpu_ids);
@@ -400,6 +411,9 @@ TORCH_LIBRARY_FRAGMENT(sgl_kernel, m) {
   // fused_gdn_gating
   m.def("fused_gdn_gating_cpu(Tensor A_log, Tensor a, Tensor dt_bias) -> Tensor");
   m.impl("fused_gdn_gating_cpu", torch::kCPU, &fused_gdn_gating_cpu);
+  // fused_recurrent_gated_delta_rule
+  m.def("fused_recurrent_gated_delta_rule_cpu(Tensor query, Tensor key, Tensor value, Tensor g, Tensor beta, Tensor cache_indices, Tensor(a!) initial_state, bool use_qk_l2norm_in_kernel) -> Tensor");
+  m.impl("fused_recurrent_gated_delta_rule_cpu", torch::kCPU, &fused_recurrent_gated_delta_rule_cpu);
 }
 
 TORCH_LIBRARY_IMPL(sgl_kernel, CatchAll, m) {

--- a/sgl-kernel/csrc/cpu/torch_extension_cpu.cpp
+++ b/sgl-kernel/csrc/cpu/torch_extension_cpu.cpp
@@ -29,6 +29,7 @@ at::Tensor gelu_and_mul_cpu(const at::Tensor& input);
 
 // l2norm
 at::Tensor l2norm_cpu(at::Tensor& input, double eps);
+at::Tensor qwen3_next_l2norm_cpu(at::Tensor& input, double eps);
 
 // rmsnorm
 at::Tensor rmsnorm_cpu(at::Tensor& input, at::Tensor& weight, double eps);
@@ -287,6 +288,8 @@ TORCH_LIBRARY_FRAGMENT(sgl_kernel, m) {
   m.impl("gemma_rmsnorm_cpu", torch::kCPU, &gemma_rmsnorm_cpu);
   m.def("l2norm_cpu(Tensor input, float eps) -> Tensor");
   m.impl("l2norm_cpu", torch::kCPU, &l2norm_cpu);
+  m.def("qwen3_next_l2norm_cpu(Tensor input, float eps) -> Tensor");
+  m.impl("qwen3_next_l2norm_cpu", torch::kCPU, &qwen3_next_l2norm_cpu);
   m.def("qwen3_next_rmsnorm_gated_cpu(Tensor input, Tensor weight, Tensor gate, float eps) -> Tensor");
   m.impl("qwen3_next_rmsnorm_gated_cpu", torch::kCPU, &qwen3_next_rmsnorm_gated_cpu);
   m.def("fused_add_rmsnorm_cpu(Tensor(a!) input, Tensor residual, Tensor weight, float eps) -> ()");

--- a/sgl-kernel/csrc/cpu/torch_extension_cpu.cpp
+++ b/sgl-kernel/csrc/cpu/torch_extension_cpu.cpp
@@ -237,7 +237,7 @@ std::tuple<at::Tensor, at::Tensor> rotary_embedding_cpu(
     bool is_neox);
 
 // fused_gdn_gating
-at::Tensor fused_gdn_gating_cpu(at::Tensor& A_log, at::Tensor& a, at::Tensor& dt_bias);
+at::Tensor fused_gdn_gating_cpu(const at::Tensor& A_log, const at::Tensor& a, const at::Tensor& dt_bias);
 // fused_recurrent_gated_delta_rule
 at::Tensor fused_recurrent_gated_delta_rule_cpu(
   const at::Tensor& query,
@@ -245,6 +245,19 @@ at::Tensor fused_recurrent_gated_delta_rule_cpu(
   const at::Tensor& value,
   const at::Tensor& g,
   const at::Tensor& beta,
+  const at::Tensor& cache_indices,
+  at::Tensor& initial_state,
+  bool use_qk_l2norm_in_kernel
+);
+// fused_sigmoid_gating_delta_rule_update
+at::Tensor fused_sigmoid_gating_delta_rule_update_cpu(
+  const at::Tensor& query,
+  const at::Tensor& key,
+  const at::Tensor& value,
+  const at::Tensor& A_log,
+  const at::Tensor& a,
+  const at::Tensor& dt_bias,
+  const at::Tensor& b,
   const at::Tensor& cache_indices,
   at::Tensor& initial_state,
   bool use_qk_l2norm_in_kernel
@@ -417,6 +430,9 @@ TORCH_LIBRARY_FRAGMENT(sgl_kernel, m) {
   // fused_recurrent_gated_delta_rule
   m.def("fused_recurrent_gated_delta_rule_cpu(Tensor query, Tensor key, Tensor value, Tensor g, Tensor beta, Tensor cache_indices, Tensor(a!) initial_state, bool use_qk_l2norm_in_kernel) -> Tensor");
   m.impl("fused_recurrent_gated_delta_rule_cpu", torch::kCPU, &fused_recurrent_gated_delta_rule_cpu);
+  // fused_sigmoid_gating_delta_rule_update
+m.def("fused_sigmoid_gating_delta_rule_update_cpu(Tensor query, Tensor key, Tensor value, Tensor A_log, Tensor a, Tensor dt_bias, Tensor b, Tensor cache_indices, Tensor(a!) initial_state, bool use_qk_l2norm_in_kernel) -> Tensor");
+  m.impl("fused_sigmoid_gating_delta_rule_update_cpu", torch::kCPU, &fused_sigmoid_gating_delta_rule_update_cpu);
 }
 
 TORCH_LIBRARY_IMPL(sgl_kernel, CatchAll, m) {

--- a/test/srt/cpu/test_mamba.py
+++ b/test/srt/cpu/test_mamba.py
@@ -83,12 +83,14 @@ class TestMambaAttention(CustomTestCase):
         query = torch.rand(batch_size, seq_len, num_heads, head_k_dim, dtype=torch.bfloat16)
         key = torch.rand(batch_size, seq_len, num_heads, head_k_dim, dtype=torch.bfloat16)
         value = torch.rand(batch_size, seq_len, num_value_heads, head_v_dim, dtype=torch.bfloat16)
-        g = torch.rand(batch_size, num_value_heads, dtype=torch.float32)
-        beta = torch.rand(batch_size, num_value_heads, dtype=torch.bfloat16)
+        A_log = torch.rand(num_value_heads, dtype=torch.float32)
+        a = torch.rand(batch_size, num_value_heads, dtype=torch.float32)
+        dt_bias = torch.rand(num_value_heads, dtype=torch.float32)
+        g = -A_log.exp() * softplus(a + dt_bias)
+        beta = torch.rand(batch_size, num_value_heads, dtype=torch.bfloat16).sigmoid()
         ssm_states = torch.rand(513, num_value_heads, head_k_dim, head_v_dim, dtype=torch.float32)
         cache_indices = torch.randint(0, 513, (batch_size,), dtype=torch.int32)
-        # use_qk_l2norm_in_kernel = True
-        use_qk_l2norm_in_kernel = False
+        use_qk_l2norm_in_kernel = True
         query_start_loc = torch.tensor([0, 1], dtype=torch.int32)
         query_ref = query.clone()
         key_ref = key.clone()
@@ -116,7 +118,7 @@ class TestMambaAttention(CustomTestCase):
             use_qk_l2norm_in_kernel
         )
         last_recurrent_state = ssm_states[cache_indices]
-        atol = rtol = precision[g.dtype]
+        atol = rtol = precision[core_attn_out.dtype]
         self.assertTrue(torch.allclose(core_attn_out, core_attn_out_ref, atol=atol, rtol=rtol))
         self.assertTrue(torch.allclose(last_recurrent_state, last_recurrent_state_ref, atol=atol, rtol=rtol))
 

--- a/test/srt/cpu/test_mamba.py
+++ b/test/srt/cpu/test_mamba.py
@@ -29,19 +29,19 @@ def torch_recurrent_gated_delta_rule(
         x.transpose(1, 2).contiguous().to(torch.float32) for x in (query, key, value, beta, g)
     ]
 
-    batch_size, sequence_length, num_heads, k_head_dim = key.shape
+    batch_size, num_heads, sequence_length, k_head_dim = key.shape
     v_head_dim = value.shape[-1]
     scale = 1 / (query.shape[-1] ** 0.5)
     query = query * scale
 
-    core_attn_out = torch.zeros(batch_size, sequence_length, num_heads, v_head_dim).to(value)
+    core_attn_out = torch.zeros(batch_size, num_heads, sequence_length, v_head_dim).to(value)
     last_recurrent_state = (
-        torch.zeros(batch_size, sequence_length, k_head_dim, v_head_dim).to(value)
+        torch.zeros(batch_size, num_heads, k_head_dim, v_head_dim).to(value)
         if initial_state is None
         else initial_state.to(value)
     )
 
-    for i in range(num_heads):
+    for i in range(sequence_length):
         q_t = query[:, :, i]
         k_t = key[:, :, i]
         v_t = value[:, :, i]
@@ -89,9 +89,9 @@ class TestMambaAttention(CustomTestCase):
         head_v_dim = 128
         num_heads = 16
         seq_len = 1
-        query = torch.rand(batch_size, seq_len, num_heads, head_k_dim, dtype=torch.bfloat16)
-        key = torch.rand(batch_size, seq_len, num_heads, head_k_dim, dtype=torch.bfloat16)
-        value = torch.rand(batch_size, seq_len, num_value_heads, head_v_dim, dtype=torch.bfloat16)
+        query = torch.rand(seq_len, batch_size, num_heads, head_k_dim, dtype=torch.bfloat16)
+        key = torch.rand(seq_len, batch_size, num_heads, head_k_dim, dtype=torch.bfloat16)
+        value = torch.rand(seq_len, batch_size, num_value_heads, head_v_dim, dtype=torch.bfloat16)
         A_log = torch.rand(num_value_heads, dtype=torch.float32)
         a = torch.rand(batch_size, num_value_heads, dtype=torch.float32)
         dt_bias = torch.rand(num_value_heads, dtype=torch.float32)
@@ -138,12 +138,12 @@ class TestMambaAttention(CustomTestCase):
         head_v_dim = 128
         num_heads = 16
         seq_len = 1
-        query = torch.rand(batch_size, seq_len, num_heads, head_k_dim, dtype=torch.bfloat16)
-        key = torch.rand(batch_size, seq_len, num_heads, head_k_dim, dtype=torch.bfloat16)
-        value = torch.rand(batch_size, seq_len, num_value_heads, head_v_dim, dtype=torch.bfloat16)
+        query = torch.rand(seq_len, batch_size, num_heads, head_k_dim, dtype=torch.bfloat16)
+        key = torch.rand(seq_len, batch_size, num_heads, head_k_dim, dtype=torch.bfloat16)
+        value = torch.rand(seq_len, batch_size, num_value_heads, head_v_dim, dtype=torch.bfloat16)
         A_log = torch.rand(num_value_heads, dtype=torch.float32)
-        a = torch.rand(seq_len, num_value_heads, dtype=torch.bfloat16)
-        b = torch.rand(seq_len, num_value_heads, dtype=torch.bfloat16)
+        a = torch.rand(batch_size, num_value_heads, dtype=torch.bfloat16)
+        b = torch.rand(batch_size, num_value_heads, dtype=torch.bfloat16)
         dt_bias = torch.rand(num_value_heads, dtype=torch.bfloat16)
         ssm_states = torch.rand(513, num_value_heads, head_k_dim, head_v_dim, dtype=torch.float32)
         cache_indices = torch.randint(0, 513, (batch_size,), dtype=torch.int32)

--- a/test/srt/cpu/test_mamba.py
+++ b/test/srt/cpu/test_mamba.py
@@ -60,6 +60,15 @@ def torch_recurrent_gated_delta_rule(
     return core_attn_out, last_recurrent_state
 
 
+def sigmoid_gating_delta_rule_update(query, key, value, A_log, a, dt_bias, b, initial_state, output_final_state, use_qk_l2norm_in_kernel=False
+):
+    beta = b.sigmoid()
+    g = -A_log.float().exp() * softplus(a.float() + dt_bias)
+    return torch_recurrent_gated_delta_rule(
+        query, key, value, g.unsqueeze(0), beta.unsqueeze(0), initial_state, output_final_state, use_qk_l2norm_in_kernel=use_qk_l2norm_in_kernel
+    )
+
+
 class TestMambaAttention(CustomTestCase):
     def test_fused_gdn_gating(self):
         dims = [6, 32]
@@ -113,6 +122,57 @@ class TestMambaAttention(CustomTestCase):
             value,
             g,
             beta,
+            cache_indices,
+            ssm_states,
+            use_qk_l2norm_in_kernel
+        )
+        last_recurrent_state = ssm_states[cache_indices]
+        atol = rtol = precision[core_attn_out.dtype]
+        self.assertTrue(torch.allclose(core_attn_out, core_attn_out_ref, atol=atol, rtol=rtol))
+        self.assertTrue(torch.allclose(last_recurrent_state, last_recurrent_state_ref, atol=atol, rtol=rtol))
+
+    def test_fused_sigmoid_gating_delta_rule_update(self):
+        batch_size = 1
+        num_value_heads = 32
+        head_k_dim = 128
+        head_v_dim = 128
+        num_heads = 16
+        seq_len = 1
+        query = torch.rand(batch_size, seq_len, num_heads, head_k_dim, dtype=torch.bfloat16)
+        key = torch.rand(batch_size, seq_len, num_heads, head_k_dim, dtype=torch.bfloat16)
+        value = torch.rand(batch_size, seq_len, num_value_heads, head_v_dim, dtype=torch.bfloat16)
+        A_log = torch.rand(num_value_heads, dtype=torch.float32)
+        a = torch.rand(seq_len, num_value_heads, dtype=torch.bfloat16)
+        b = torch.rand(seq_len, num_value_heads, dtype=torch.bfloat16)
+        dt_bias = torch.rand(num_value_heads, dtype=torch.bfloat16)
+        ssm_states = torch.rand(513, num_value_heads, head_k_dim, head_v_dim, dtype=torch.float32)
+        cache_indices = torch.randint(0, 513, (batch_size,), dtype=torch.int32)
+        use_qk_l2norm_in_kernel = True
+        query_ref = query.clone()
+        key_ref = key.clone()
+        if num_value_heads // num_heads > 1:
+            query_ref = query_ref.repeat_interleave(num_value_heads // num_heads, dim=2)
+            key_ref = key_ref.repeat_interleave(num_value_heads // num_heads, dim=2)
+        core_attn_out_ref, last_recurrent_state_ref = sigmoid_gating_delta_rule_update(
+            query_ref.transpose(0, 1),
+            key_ref.transpose(0, 1),
+            value.transpose(0, 1),
+            A_log,
+            a,
+            dt_bias,
+            b,
+            initial_state=ssm_states[cache_indices],
+            output_final_state=True,
+            use_qk_l2norm_in_kernel=use_qk_l2norm_in_kernel
+        )
+        core_attn_out = torch.ops.sgl_kernel.fused_sigmoid_gating_delta_rule_update_cpu(
+            query,
+            key,
+            value,
+            A_log,
+            a,
+            dt_bias,
+            b,
             cache_indices,
             ssm_states,
             use_qk_l2norm_in_kernel

--- a/test/srt/cpu/test_mamba.py
+++ b/test/srt/cpu/test_mamba.py
@@ -13,6 +13,52 @@ torch.manual_seed(1234)
 def torch_gdn_gating(A_log, a, dt_bias):
     return -A_log.float().exp() * softplus(a.float() + dt_bias)
 
+def l2norm(x: torch.FloatTensor, dim: int = -1, eps: float = 1e-6):
+    """This function is intended to align with the l2norm implementation in the FLA library."""
+    inv_norm = torch.rsqrt((x * x).sum(dim=dim, keepdim=True) + eps)
+    return x * inv_norm
+
+def torch_recurrent_gated_delta_rule(
+    query, key, value, g, beta, initial_state, output_final_state, use_qk_l2norm_in_kernel=False
+):
+    initial_dtype = query.dtype
+    if use_qk_l2norm_in_kernel:
+        query = l2norm(query, dim=-1, eps=1e-6)
+        key = l2norm(key, dim=-1, eps=1e-6)
+    query, key, value, beta, g = [
+        x.transpose(1, 2).contiguous().to(torch.float32) for x in (query, key, value, beta, g)
+    ]
+
+    batch_size, sequence_length, num_heads, k_head_dim = key.shape
+    v_head_dim = value.shape[-1]
+    scale = 1 / (query.shape[-1] ** 0.5)
+    query = query * scale
+
+    core_attn_out = torch.zeros(batch_size, sequence_length, num_heads, v_head_dim).to(value)
+    last_recurrent_state = (
+        torch.zeros(batch_size, sequence_length, k_head_dim, v_head_dim).to(value)
+        if initial_state is None
+        else initial_state.to(value)
+    )
+
+    for i in range(num_heads):
+        q_t = query[:, :, i]
+        k_t = key[:, :, i]
+        v_t = value[:, :, i]
+        g_t = g[:, :, i].exp().unsqueeze(-1).unsqueeze(-1)
+        beta_t = beta[:, :, i].unsqueeze(-1)
+
+        last_recurrent_state = last_recurrent_state * g_t
+        kv_mem = (last_recurrent_state * k_t.unsqueeze(-1)).sum(dim=-2)
+        delta = (v_t - kv_mem) * beta_t
+        last_recurrent_state = last_recurrent_state + k_t.unsqueeze(-1) * delta.unsqueeze(-2)
+        core_attn_out[:, :, i] = (last_recurrent_state * q_t.unsqueeze(-1)).sum(dim=-2)
+
+    if not output_final_state:
+        last_recurrent_state = None
+    core_attn_out = core_attn_out.transpose(1, 2).contiguous().to(initial_dtype)
+    return core_attn_out, last_recurrent_state
+
 
 class TestMambaAttention(CustomTestCase):
     def test_fused_gdn_gating(self):
@@ -26,6 +72,53 @@ class TestMambaAttention(CustomTestCase):
             g_sgl = torch.ops.sgl_kernel.fused_gdn_gating_cpu(A_log, a, dt_bias)
             atol = rtol = precision[g.dtype]
             self.assertTrue(torch.allclose(g, g_sgl, atol=atol, rtol=rtol))
+
+    def test_recurrent_gated_delta_rule(self):
+        batch_size = 1
+        num_value_heads = 32
+        head_k_dim = 128
+        head_v_dim = 128
+        num_heads = 16
+        seq_len = 1
+        query = torch.rand(batch_size, seq_len, num_heads, head_k_dim, dtype=torch.bfloat16)
+        key = torch.rand(batch_size, seq_len, num_heads, head_k_dim, dtype=torch.bfloat16)
+        value = torch.rand(batch_size, seq_len, num_value_heads, head_v_dim, dtype=torch.bfloat16)
+        g = torch.rand(batch_size, num_value_heads, dtype=torch.float32)
+        beta = torch.rand(batch_size, num_value_heads, dtype=torch.bfloat16)
+        ssm_states = torch.rand(513, num_value_heads, head_k_dim, head_v_dim, dtype=torch.float32)
+        cache_indices = torch.randint(0, 513, (batch_size,), dtype=torch.int32)
+        # use_qk_l2norm_in_kernel = True
+        use_qk_l2norm_in_kernel = False
+        query_start_loc = torch.tensor([0, 1], dtype=torch.int32)
+        query_ref = query.clone()
+        key_ref = key.clone()
+        if num_value_heads // num_heads > 1:
+            query_ref = query_ref.repeat_interleave(num_value_heads // num_heads, dim=2)
+            key_ref = key_ref.repeat_interleave(num_value_heads // num_heads, dim=2)
+        core_attn_out_ref, last_recurrent_state_ref = torch_recurrent_gated_delta_rule(
+            query_ref.transpose(0, 1),
+            key_ref.transpose(0, 1),
+            value.transpose(0, 1),
+            g=g.unsqueeze(0),
+            beta=beta.unsqueeze(0),
+            initial_state=ssm_states[cache_indices],
+            output_final_state=True,
+            use_qk_l2norm_in_kernel=use_qk_l2norm_in_kernel
+        )
+        core_attn_out = torch.ops.sgl_kernel.fused_recurrent_gated_delta_rule_cpu(
+            query,
+            key,
+            value,
+            g,
+            beta,
+            cache_indices,
+            ssm_states,
+            use_qk_l2norm_in_kernel
+        )
+        last_recurrent_state = ssm_states[cache_indices]
+        atol = rtol = precision[g.dtype]
+        self.assertTrue(torch.allclose(core_attn_out, core_attn_out_ref, atol=atol, rtol=rtol))
+        self.assertTrue(torch.allclose(last_recurrent_state, last_recurrent_state_ref, atol=atol, rtol=rtol))
 
 
 if __name__ == "__main__":

--- a/test/srt/cpu/test_norm.py
+++ b/test/srt/cpu/test_norm.py
@@ -37,6 +37,10 @@ class TestNorm(CustomTestCase):
         else:
             return x, residual
 
+    def _qwen3_next_l2norm(self, x: torch.FloatTensor, dim: int = -1, eps: float = 1e-6):
+        inv_norm = torch.rsqrt((x * x).sum(dim=dim, keepdim=True) + eps)
+        return x * inv_norm
+
     def _gemma_rmsnorm_native(
         self,
         x: torch.Tensor,
@@ -127,12 +131,33 @@ class TestNorm(CustomTestCase):
         atol = rtol = precision[ref_out.dtype]
         torch.testing.assert_close(ref_out, out, atol=atol, rtol=rtol)
 
+    def _qwen3_next_l2norm_test(self, m, n, dtype):
+
+        x = torch.randn([m, n], dtype=dtype)
+        variance_epsilon = 1e-6
+
+        out = torch.ops.sgl_kernel.qwen3_next_l2norm_cpu(x, variance_epsilon)
+        ref_out = self._qwen3_next_l2norm(x, eps=variance_epsilon)
+
+        atol = rtol = precision[ref_out.dtype]
+        torch.testing.assert_close(ref_out, out, atol=atol, rtol=rtol)
+
+        x = torch.randn([1, 2, m, n], dtype=dtype)
+        variance_epsilon = 1e-6
+
+        out = torch.ops.sgl_kernel.qwen3_next_l2norm_cpu(x, variance_epsilon)
+        ref_out = self._qwen3_next_l2norm(x, eps=variance_epsilon)
+
+        atol = rtol = precision[ref_out.dtype]
+        torch.testing.assert_close(ref_out, out, atol=atol, rtol=rtol)
+
     def test_norm(self):
         for params in itertools.product(self.M, self.N, self.dtype):
             with self.subTest(m=params[0], n=params[1], dtype=params[2]):
                 self._norm_test(*params)
                 self._l2norm_test(*params)
                 self._gemma_rmsnorm_test(*params)
+                self._qwen3_next_l2norm_test(*params)
 
 
 class TestQwen3NextRMSNormGated(CustomTestCase):


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
This pr adds kernel for fused_sigmoid_gating_delta_rule_update_cpu and fused_recurrent_gated_delta_rule_cpu
<img width="364" height="111" alt="image" src="https://github.com/user-attachments/assets/0af6ba77-4000-4a34-b94b-b129aa0a0175" />

**Performance on local machine:**
**command:**
`SGLANG_USE_CPU_ENGINE=1 SGLANG_CPU_OMP_THREADS_BIND="0-31|32-63|64-95|96-127|128-159|160-191" python3 -m sglang.bench_one_batch --batch-size 1 --input 1024 --output 1024 --model   /localdisk/models/qwen80b-next-instruct/ --trust-remote-code --device cpu --tp 6  --dtype bfloat16`
**Before:**
Benchmark ...
Prefill. latency: 1.06509 s, throughput:    961.42 token/s
Decode 0. Batch size: 1, latency: 0.05318 s, throughput:     18.80 token/s
Decode 1. Batch size: 1, latency: 0.05250 s, throughput:     19.05 token/s
Decode 2. Batch size: 1, latency: 0.05219 s, throughput:     19.16 token/s
Decode 3. Batch size: 1, latency: 0.05202 s, throughput:     19.22 token/s
Decode 4. Batch size: 1, latency: 0.05167 s, throughput:     19.35 token/s
Decode.  median latency: 0.06672 s, median throughput:     **14.99 token/s**
Total. latency: 69.039 s, throughput:     29.66 token/s
**After:**
Benchmark ...
Prefill. latency: 1.06914 s, throughput:    957.78 token/s
Decode 0. Batch size: 1, latency: 0.04122 s, throughput:     24.26 token/s
Decode 1. Batch size: 1, latency: 0.04066 s, throughput:     24.59 token/s
Decode 2. Batch size: 1, latency: 0.04067 s, throughput:     24.59 token/s
Decode 3. Batch size: 1, latency: 0.03981 s, throughput:     25.12 token/s
Decode 4. Batch size: 1, latency: 0.03982 s, throughput:     25.11 token/s
Decode.  median latency: 0.03945 s, median throughput:     **25.35 token/s**
Total. latency: 41.444 s, throughput:     49.42 token/s


**Accuracy test:**
**command:**
server:`SGLANG_USE_CPU_ENGINE=1 python -m sglang.launch_server  --model /localdisk/models/qwen80b-next-instruct/ --trust-remote-code --device cpu --tp 6 --dtype bfloat16   --mem-fraction-static 0.8 --max-total-tokens 65536  --disable-overlap-schedule --disable-radix-cache`
client:`python bench_sglang.py  --num-questions 1000 --parallel 16`
Accuracy: 0.940
Invalid: 0.000
Latency: 1923.851 s
Output throughput: 86.759 token/s


Further optimization opportunities: reduce overheads from qkv splits.

## Modifications

<!-- Describe the changes made in this PR. -->

## Checklist

- [ ] Format your code according to the [Contributor Guide](https://github.com/sgl-project/sglang/blob/main/docs/references/contributor_guide.md).
- [ ] Add unit tests as outlined in the [Contributor Guide](https://github.com/sgl-project/sglang/blob/main/docs/references/contributor_guide.md).
- [ ] Update documentation as needed, including docstrings or example tutorials.
