### PR TITLE
Add torch.compile support for qwen3-next on CPU

### DIFF
--- a/python/sglang/srt/layers/attention/intel_amx_backend.py
+++ b/python/sglang/srt/layers/attention/intel_amx_backend.py
@@ -49,8 +49,34 @@ class IntelAMXAttnBackend(AttentionBackend):
             max_extend_len = torch.max(forward_batch.extend_seq_lens).item()
         self.forward_metadata = (attn_logits, max_extend_len)
 
-    def get_graph_seq_len_fill_value(self):
+    def get_cpu_graph_seq_len_fill_value(self):
         return 1
+
+    def init_forward_metadata_capture_cpu_graph(
+        self,
+        bs: int,
+        num_tokens: int,
+        req_pool_indices: torch.Tensor,
+        seq_lens: torch.Tensor,
+        encoder_lens,
+        forward_mode,
+        spec_info,
+    ):
+        attn_logits = torch.zeros(
+            (
+                bs,
+                self.num_head,
+                8,  # self.num_kv_splits,
+                self.v_head_dim + 1,
+            ),
+            dtype=torch.float32,
+            device=self.device,
+        )
+        max_extend_len = None
+        self.forward_metadata = (attn_logits, max_extend_len)
+
+    def init_cpu_graph_state(self, max_bs: int, max_num_tokens: int):
+        pass
 
     def forward_extend(
         self,

--- a/python/sglang/srt/layers/attention/torch_native_hybrid_linear_attn_backend.py
+++ b/python/sglang/srt/layers/attention/torch_native_hybrid_linear_attn_backend.py
@@ -293,6 +293,15 @@ class MambaAttnBackend(AttentionBackend):
                 torch.empty((i + 2,), dtype=torch.int32, device="cuda")
             )
 
+    def init_cpu_graph_state(self, max_bs: int, max_num_tokens: int):
+        for i in range(max_bs):
+            self.state_indices_list.append(
+                torch.arange(0, i + 1, dtype=torch.int32, device="cpu")
+            )
+            self.query_start_loc_list.append(
+                torch.empty((i + 2,), dtype=torch.int32, device="cpu")
+            )
+
     def init_forward_metadata_capture_cuda_graph(
         self,
         bs: int,
@@ -319,6 +328,25 @@ class MambaAttnBackend(AttentionBackend):
             raise ValueError(f"Invalid forward mode: {forward_mode=}")
         mamba_indices = self.req_to_token_pool.get_mamba_indices(req_pool_indices)
         self.state_indices_list[bs - 1][: len(mamba_indices)].copy_(mamba_indices)
+        self.forward_metadata = ForwardMetadata(
+            query_start_loc=self.query_start_loc_list[bs - 1],
+            mamba_cache_indices=self.state_indices_list[bs - 1],
+        )
+
+    def init_forward_metadata_capture_cpu_graph(
+        self,
+        bs: int,
+        num_tokens: int,
+        req_pool_indices: torch.Tensor,
+        seq_lens: torch.Tensor,
+        encoder_lens: Optional[torch.Tensor],
+        forward_mode: ForwardMode,
+        spec_info: Optional[Union[EagleDraftInput, EagleVerifyInput]],
+    ):
+        if forward_mode.is_decode_or_idle():
+            self.query_start_loc_list[bs - 1].copy_(self._get_cached_arange(bs, "cpu"))
+        else:
+            raise ValueError(f"Invalid forward mode: {forward_mode=}")
         self.forward_metadata = ForwardMetadata(
             query_start_loc=self.query_start_loc_list[bs - 1],
             mamba_cache_indices=self.state_indices_list[bs - 1],
@@ -370,6 +398,9 @@ class MambaAttnBackend(AttentionBackend):
         )
 
     def get_cuda_graph_seq_len_fill_value(self):
+        return 1  # Mamba attn does not use seq lens to index kv cache
+
+    def get_cpu_graph_seq_len_fill_value(self):
         return 1  # Mamba attn does not use seq lens to index kv cache
 
     def forward_decode(
@@ -556,6 +587,10 @@ class HybridLinearAttnBackend(AttentionBackend):
         for attn_backend in self.attn_backend_list:
             attn_backend.init_cuda_graph_state(max_bs, max_num_tokens)
 
+    def init_cpu_graph_state(self, max_bs: int, max_num_tokens: int):
+        for attn_backend in self.attn_backend_list:
+            attn_backend.init_cpu_graph_state(max_bs, max_num_tokens)
+
     def init_forward_metadata_capture_cuda_graph(
         self,
         bs: int,
@@ -568,6 +603,27 @@ class HybridLinearAttnBackend(AttentionBackend):
     ):
         for attn_backend in self.attn_backend_list:
             attn_backend.init_forward_metadata_capture_cuda_graph(
+                bs,
+                num_tokens,
+                req_pool_indices,
+                seq_lens,
+                encoder_lens,
+                forward_mode,
+                spec_info,
+            )
+
+    def init_forward_metadata_capture_cpu_graph(
+        self,
+        bs: int,
+        num_tokens: int,
+        req_pool_indices: torch.Tensor,
+        seq_lens: torch.Tensor,
+        encoder_lens: Optional[torch.Tensor],
+        forward_mode: ForwardMode,
+        spec_info: Optional[Union[EagleDraftInput, EagleVerifyInput]],
+    ):
+        for attn_backend in self.attn_backend_list:
+            attn_backend.init_forward_metadata_capture_cpu_graph(
                 bs,
                 num_tokens,
                 req_pool_indices,
@@ -603,6 +659,9 @@ class HybridLinearAttnBackend(AttentionBackend):
     def get_cuda_graph_seq_len_fill_value(self):
         return 1
         # return self.attn_backend_list[0].get_cuda_graph_seq_len_fill_value()
+
+    def get_cpu_graph_seq_len_fill_value(self):
+        return 1
 
     def forward_decode(
         self,

--- a/python/sglang/srt/model_executor/cpu_graph_runner.py
+++ b/python/sglang/srt/model_executor/cpu_graph_runner.py
@@ -114,6 +114,7 @@ def register_fake_ops():
         "fused_add_rmsnorm_cpu",
         "decode_attention_cpu",
         "extend_attention_cpu",
+        "gemma_fused_add_rmsnorm_cpu",
     ]
     for op in none_return_ops:
 
@@ -126,6 +127,9 @@ def register_fake_ops():
         "l2norm_cpu",
         "fused_experts_cpu",
         "shared_expert_cpu",
+        "gemma_rmsnorm_cpu",
+        "causal_conv1d_update_cpu_ori",
+        "qwen3_next_rmsnorm_gated_cpu",
     ]:
 
         @torch.library.register_fake(f"sgl_kernel::{op}")
@@ -337,6 +341,90 @@ def register_fake_ops():
         N = mat2.shape[0]
         return mat1.new_empty(M, N, dtype=out_dtype)
 
+    @torch.library.register_fake("sgl_kernel::fused_qkvzba_split_reshape_cat_cpu")
+    def _(
+        mixed_qkvz,
+        mixed_ba,
+        num_heads_qk,
+        num_heads_v,
+        head_qk,
+        head_v
+    ):
+        batch = mixed_qkvz.shape[0]
+        qkv_dim = num_heads_qk * head_qk * 2 + num_heads_v * head_v
+        mixed_qkv = mixed_qkvz.new_empty(batch, qkv_dim)
+        z = mixed_qkvz.new_empty(batch, num_heads_v, head_v)
+        b = mixed_ba.new_empty(batch, num_heads_v)
+        a = mixed_ba.new_empty(batch, num_heads_v)
+        return mixed_qkv, z, b, a
+
+    @torch.library.register_fake("sgl_kernel::fused_sigmoid_gating_delta_rule_update_cpu")
+    def _(
+        mixed_qkv,
+        A_log,
+        a,
+        dt_bias,
+        b,
+        cache_indices,
+        initial_state,
+        use_qk_l2norm_in_kernel
+    ):
+        batch_size = mixed_qkv.shape[0]
+        seq_len = 1
+        v_num_heads = initial_state.shape[1]
+        v_head_dim = initial_state.shape[3]
+        return mixed_qkv.new_empty(batch_size, seq_len, v_num_heads, v_head_dim)
+
+    @torch.library.register_fake("sgl_kernel::fma_linear")
+    def _(
+        mat1,
+        mat2,
+        bias,
+        post_mul
+    ):
+        M = mat1.shape[0]
+        N = mat2.shape[1]
+        K = mat1.shape[1]
+        if post_mul is not None:
+            return mat1.new_empty(M, K)
+        else:
+            return mat1.new_empty(M, N)
+
+    @torch.library.register_fake("sgl_kernel::chunk_gated_delta_rule_cpu")
+    def _(
+        query,
+        key,
+        value,
+        g,
+        beta,
+        cu_seqlens,
+        initial_state,
+        use_qk_l2norm_in_kernel
+    ):
+        output = torch.empty_like(value)
+        assert initial_state is not None
+        final_state = initial_state.to(torch.float32)
+
+        return output, final_state
+
+    @torch.library.register_fake("sgl_kernel::fused_recurrent_gated_delta_rule_cpu")
+    def _(
+        query,
+        key,
+        value,
+        g,
+        beta,
+        cache_indices,
+        initial_state,
+        use_qk_l2norm_in_kernel
+    ):
+        batch_size = query.shape[1]
+        seq_len = query.shape[0]
+        v_num_heads = value.shape[2]
+        v_head_dim = value.shape[3]
+        output = query.new_empty(batch_size, seq_len, v_num_heads, v_head_dim)
+        return output
+
 
 # TODO Remove unnecessary settings for CPUGraphRunner.
 # Re-abstract the graph runner and restructure CPUGraphRunner to reuse the same logic.
@@ -407,8 +495,12 @@ class CPUGraphRunner:
         self.max_bs = max(self.capture_bs)
         self.max_num_token = self.max_bs * self.num_tokens_per_bs
 
+        self.model_runner.attn_backend.init_cpu_graph_state(
+            self.max_bs, self.max_num_token
+        )
+
         self.seq_len_fill_value = (
-            self.model_runner.attn_backend.get_graph_seq_len_fill_value()
+            self.model_runner.attn_backend.get_cpu_graph_seq_len_fill_value()
         )
 
         if self.enable_torch_compile:
@@ -497,7 +589,7 @@ class CPUGraphRunner:
         seq_lens = self.seq_lens[:bs]
         out_cache_loc = self.out_cache_loc[:num_tokens]
         positions = self.positions[:num_tokens]
-        mrope_positions = self.mrope_positions[:, :bs]
+        mrope_positions = self.mrope_positions[:, :num_tokens]
         self.num_token_non_padded[...] = num_tokens
 
         spec_info = self.get_spec_info(num_tokens)
@@ -526,17 +618,24 @@ class CPUGraphRunner:
             num_token_non_padded=self.num_token_non_padded,
             global_forward_mode=self.capture_forward_mode,
         )
-
-        # Attention backend
-        self.model_runner.attn_backend.init_forward_metadata(forward_batch)
+        self.model_runner.attn_backend.init_forward_metadata_capture_cpu_graph(
+            bs,
+            num_tokens,
+            req_pool_indices,
+            seq_lens,
+            None,
+            forward_batch.forward_mode,
+            forward_batch.spec_info,
+        )
         # Do infernence to avoid setting attr at runtime, e.g.,
         # self.attn_mha.kv_b_proj = self.kv_b_proj for full graph compile on CPU
-        self.model_runner.model.forward(
-            forward_batch.input_ids,
-            forward_batch.positions,
-            forward_batch,
-        )
-
+        with torch.no_grad():
+            self.model_runner.tp_group.barrier()
+            self.model_runner.model.forward(
+                forward_batch.input_ids,
+                forward_batch.positions,
+                forward_batch,
+            )
         # Run and capture
         def run_once():
             # Clean intermediate result cache for DP attention

--- a/python/sglang/srt/model_executor/cpu_graph_runner.py
+++ b/python/sglang/srt/model_executor/cpu_graph_runner.py
@@ -128,7 +128,7 @@ def register_fake_ops():
         "fused_experts_cpu",
         "shared_expert_cpu",
         "gemma_rmsnorm_cpu",
-        "causal_conv1d_update_cpu_ori",
+        "causal_conv1d_update_cpu",
         "qwen3_next_rmsnorm_gated_cpu",
     ]:
 
@@ -342,14 +342,7 @@ def register_fake_ops():
         return mat1.new_empty(M, N, dtype=out_dtype)
 
     @torch.library.register_fake("sgl_kernel::fused_qkvzba_split_reshape_cat_cpu")
-    def _(
-        mixed_qkvz,
-        mixed_ba,
-        num_heads_qk,
-        num_heads_v,
-        head_qk,
-        head_v
-    ):
+    def _(mixed_qkvz, mixed_ba, num_heads_qk, num_heads_v, head_qk, head_v):
         batch = mixed_qkvz.shape[0]
         qkv_dim = num_heads_qk * head_qk * 2 + num_heads_v * head_v
         mixed_qkv = mixed_qkvz.new_empty(batch, qkv_dim)
@@ -358,7 +351,9 @@ def register_fake_ops():
         a = mixed_ba.new_empty(batch, num_heads_v)
         return mixed_qkv, z, b, a
 
-    @torch.library.register_fake("sgl_kernel::fused_sigmoid_gating_delta_rule_update_cpu")
+    @torch.library.register_fake(
+        "sgl_kernel::fused_sigmoid_gating_delta_rule_update_cpu"
+    )
     def _(
         mixed_qkv,
         A_log,
@@ -367,7 +362,7 @@ def register_fake_ops():
         b,
         cache_indices,
         initial_state,
-        use_qk_l2norm_in_kernel
+        use_qk_l2norm_in_kernel,
     ):
         batch_size = mixed_qkv.shape[0]
         seq_len = 1
@@ -376,12 +371,7 @@ def register_fake_ops():
         return mixed_qkv.new_empty(batch_size, seq_len, v_num_heads, v_head_dim)
 
     @torch.library.register_fake("sgl_kernel::fma_linear")
-    def _(
-        mat1,
-        mat2,
-        bias,
-        post_mul
-    ):
+    def _(mat1, mat2, bias, post_mul):
         M = mat1.shape[0]
         N = mat2.shape[1]
         K = mat1.shape[1]
@@ -392,14 +382,7 @@ def register_fake_ops():
 
     @torch.library.register_fake("sgl_kernel::chunk_gated_delta_rule_cpu")
     def _(
-        query,
-        key,
-        value,
-        g,
-        beta,
-        cu_seqlens,
-        initial_state,
-        use_qk_l2norm_in_kernel
+        query, key, value, g, beta, cu_seqlens, initial_state, use_qk_l2norm_in_kernel
     ):
         output = torch.empty_like(value)
         assert initial_state is not None
@@ -416,7 +399,7 @@ def register_fake_ops():
         beta,
         cache_indices,
         initial_state,
-        use_qk_l2norm_in_kernel
+        use_qk_l2norm_in_kernel,
     ):
         batch_size = query.shape[1]
         seq_len = query.shape[0]
@@ -636,6 +619,7 @@ class CPUGraphRunner:
                 forward_batch.positions,
                 forward_batch,
             )
+
         # Run and capture
         def run_once():
             # Clean intermediate result cache for DP attention

--- a/sgl-kernel/csrc/cpu/torch_extension_cpu.cpp
+++ b/sgl-kernel/csrc/cpu/torch_extension_cpu.cpp
@@ -354,9 +354,9 @@ TORCH_LIBRARY_FRAGMENT(sgl_kernel, m) {
   m.impl("qwen3_next_rmsnorm_gated_cpu", torch::kCPU, &qwen3_next_rmsnorm_gated_cpu);
   m.def("fused_add_rmsnorm_cpu(Tensor(a!) input, Tensor residual, Tensor weight, float eps) -> ()");
   m.impl("fused_add_rmsnorm_cpu", torch::kCPU, &fused_add_rmsnorm_cpu);
-  m.def("gemma_fused_add_rmsnorm_cpu(Tensor input, Tensor residual, Tensor weight, float eps) -> ()");
+  m.def("gemma_fused_add_rmsnorm_cpu(Tensor(a!) input, Tensor residual, Tensor weight, float eps) -> ()");
   m.impl("gemma_fused_add_rmsnorm_cpu", torch::kCPU, &gemma_fused_add_rmsnorm_cpu);
-  
+
   // topk
   m.def("topk_sigmoid_cpu(Tensor hidden_states, Tensor gating_output, int topk, bool renormalize) -> (Tensor, Tensor)");
   m.impl("topk_sigmoid_cpu", torch::kCPU, &topk_sigmoid_cpu);


### PR DESCRIPTION
## Motivation

Add torch.compile support for qwen3-next on CPU.

## Modifications

Add init forward metadata for `HybridLinearAttnBackend` and `MambaAttnBackend`.
Register more custom kernels for compile.
Fix the initial `mamba_cache_indices` for torch.compile on CPU.


## Checklist

- [ ] Format your code according to the [Contributor Guide](https://github.com/sgl-project/sglang/blob/main/docs/references/contributor_guide.md).
- [ ] Add unit tests as outlined in the [Contributor Guide](https://github.com/sgl-project/sglang/blob/main/docs/references/contributor_guide.md).
- [ ] Update documentation as needed, including docstrings or example tutorials.
