### PR TITLE
Add kernels for MOE, topk, hadamard_transform, store_cache, quant, alloc, and compressor

### DIFF
--- a/python/sglang/jit_kernel/deepseek_v4.py
+++ b/python/sglang/jit_kernel/deepseek_v4.py
@@ -904,5 +904,9 @@ def _dispatch_bf16_fp32_backend(
         z = x.new_empty(x.size(0), y.size(0), dtype=torch.float32)
         deep_gemm.bf16_gemm_nt(x, y, z)
         return z
+    elif algo == "cpu_amx":
+        return torch.ops.sgl_kernel.weight_packed_linear(
+            x, y, None, True, torch.float32
+        )
     else:
         return torch.nn.functional.linear(x.float(), y.float())

--- a/python/sglang/srt/layers/amx_utils.py
+++ b/python/sglang/srt/layers/amx_utils.py
@@ -14,6 +14,7 @@ class CPUQuantMethod(IntEnum):
     INT8_W8A8 = 1
     FP8_W8A16 = 2
     INT4_W4A8 = 3
+    MXFP4 = 4
 
 
 class CPUQuantAlgo(IntEnum):

--- a/python/sglang/srt/layers/amx_utils.py
+++ b/python/sglang/srt/layers/amx_utils.py
@@ -172,3 +172,42 @@ class PackWeightMethod:
         _amx_process_weight_after_loading(
             module, self.weight_names, self.transpose_dims
         )
+
+
+class PackWeightMethodBMM:
+    """Pack weight for batched matrix multiplication (bmm_cpu).
+
+    Replaces the default UnquantizedLinearMethod on a linear layer so that
+    the 2D weight [G*R, D] is reshaped to 3D [G, R, D] and then VNNI-packed.
+    """
+
+    def __init__(self, n_groups, group_size):
+        self.n_groups = n_groups
+        self.group_size = group_size
+
+    def process_weights_after_loading(self, module) -> None:
+        weight = module.weight
+        device = weight.device
+
+        # Reshape [G*R, D] → [G, R, D] for batched GEMM
+        weight_3d = weight.data.view(
+            self.n_groups, self.group_size, -1
+        ).contiguous()
+
+        if not dim_is_supported(weight_3d):
+            logger.warning(
+                f"Unsupported dimension for prepacking for weight "
+                f"'weight' with shape {weight_3d.shape} in {module}. "
+                f"The derived (OC, IC) dimensions must be divisible by (16, 32). "
+            )
+            module.use_intel_amx_backend = False
+            return
+
+        packed_weight = torch.nn.Parameter(
+            amx_process_weight_after_loading(weight_3d),
+            requires_grad=False,
+        )
+        module.weight = packed_weight
+        module.use_intel_amx_backend = (
+            device == torch.device("cpu") and cpu_has_amx_support()
+        )

--- a/python/sglang/srt/layers/attention/nsa/index_buf_accessor.py
+++ b/python/sglang/srt/layers/attention/nsa/index_buf_accessor.py
@@ -201,7 +201,15 @@ class GetKAndS:
 class SetK:
     @classmethod
     def execute(cls, *args, buf, **kwargs):
-        return cls.torch_fast(*args, **kwargs, buf=buf)
+        if _is_cpu and _is_cpu_amx_available:
+            pool = args[0] if args else kwargs["pool"]
+            loc = args[1] if len(args) > 1 else kwargs["loc"]
+            index_k = args[2] if len(args) > 2 else kwargs["index_k"]
+            torch.ops.sgl_kernel.set_k_cpu(
+                buf, loc, index_k, pool.page_size, pool.index_head_dim
+            )
+        else:
+            return cls.torch_fast(*args, **kwargs, buf=buf)
 
     @classmethod
     def slow(

--- a/python/sglang/srt/layers/attention/nsa/index_buf_accessor.py
+++ b/python/sglang/srt/layers/attention/nsa/index_buf_accessor.py
@@ -5,10 +5,12 @@ import triton
 import triton.language as tl
 
 from sglang.srt.layers.quantization.fp8_kernel import is_fp8_fnuz
-from sglang.srt.utils import is_hip
+from sglang.srt.utils import cpu_has_amx_support, is_cpu, is_hip
 
 _is_hip = is_hip()
 _is_fp8_fnuz = is_fp8_fnuz()
+_is_cpu = is_cpu()
+_is_cpu_amx_available = cpu_has_amx_support()
 
 if TYPE_CHECKING:
     from sglang.srt.mem_cache.memory_pool import NSATokenToKVPool
@@ -249,7 +251,15 @@ class SetK:
 class SetS:
     @classmethod
     def execute(cls, *args, buf, **kwargs):
-        return cls.torch_fast(*args, **kwargs, buf=buf)
+        if _is_cpu and _is_cpu_amx_available:
+            pool = args[0] if args else kwargs["pool"]
+            loc = args[1] if len(args) > 1 else kwargs["loc"]
+            index_k_scale = args[2] if len(args) > 2 else kwargs["index_k_scale"]
+            torch.ops.sgl_kernel.set_s_cpu(
+                buf, loc, index_k_scale, pool.page_size, pool.index_head_dim
+            )
+        else:
+            return cls.torch_fast(*args, **kwargs, buf=buf)
 
     @classmethod
     def slow(

--- a/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
+++ b/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
@@ -220,11 +220,12 @@ class FusedMoE(torch.nn.Module):
         self.reduce_results = reduce_results
         self.use_presharded_weights = use_presharded_weights
 
-        self.use_triton_kernels = get_moe_runner_backend().is_triton_kernels()
-        self.use_flashinfer_trtllm_moe = (
-            get_moe_runner_backend().is_flashinfer_trtllm()
-            or get_moe_runner_backend().is_flashinfer_trtllm_routed()
+        self.use_triton_kernels = (
+            get_moe_runner_backend().is_triton_kernels()
+            if not (_is_cpu and _is_cpu_amx_available)
+            else False
         )
+        self.use_flashinfer_trtllm_moe = get_moe_runner_backend().is_flashinfer_trtllm()
 
         # flashinfer_trtllm kernel requires intermediate_size to be a multiple of 128
         # Pad the intermediate_size_per_partition if necessary

--- a/python/sglang/srt/layers/quantization/__init__.py
+++ b/python/sglang/srt/layers/quantization/__init__.py
@@ -45,6 +45,7 @@ from sglang.srt.layers.quantization.w4afp8 import W4AFp8Config
 from sglang.srt.layers.quantization.w8a8_fp8 import W8A8Fp8Config
 from sglang.srt.layers.quantization.w8a8_int8 import W8A8Int8Config
 from sglang.srt.utils import (
+    is_cpu,
     cpu_has_amx_support,
     is_cuda,
     is_hip,
@@ -87,7 +88,7 @@ BASE_QUANTIZATION_METHODS: Dict[str, Type[QuantizationConfig]] = {
 }
 
 
-if is_cuda() or (_is_mxfp_supported and is_hip()):
+if is_cpu() or is_cuda() or (_is_mxfp_supported and is_hip()):
     BASE_QUANTIZATION_METHODS.update(
         {
             "mxfp4": Mxfp4Config,

--- a/python/sglang/srt/layers/quantization/fp8.py
+++ b/python/sglang/srt/layers/quantization/fp8.py
@@ -1701,6 +1701,10 @@ class Fp8MoEMethod(FusedMoEMethodBase):
                 None,  # w1_zp
                 None,  # w2_zp
                 self.quant_config.weight_block_size,  # block_size
+                None,  # w1 bias
+                None,  # w3 bias
+                None,  # alpha
+                None,  # limi
                 True,  # is_vnni
             )
             return StandardCombineInput(hidden_states=output)

--- a/python/sglang/srt/layers/quantization/mxfp4.py
+++ b/python/sglang/srt/layers/quantization/mxfp4.py
@@ -35,9 +35,16 @@ from sglang.srt.layers.quantization.base_config import (
     QuantizationConfig,
     QuantizeMethodBase,
 )
+from sglang.srt.layers.amx_utils import (
+    CPUQuantMethod,
+    _amx_process_weight_after_loading,
+)
 from sglang.srt.layers.quantization.utils import is_layer_skipped
 from sglang.srt.server_args import get_global_server_args
 from sglang.srt.utils import (
+    cpu_has_amx_support,
+    is_cpu,
+    is_cuda,
     is_flashinfer_available,
     is_gfx95_supported,
     is_hip,
@@ -49,6 +56,7 @@ from sglang.srt.utils import (
     next_power_of_2,
     round_up,
     set_weight_attrs,
+    use_intel_amx_backend,
 )
 from sglang.srt.utils.common import get_bool_env_var
 from sglang.srt.utils.custom_op import register_custom_op
@@ -110,8 +118,10 @@ if TYPE_CHECKING:
         StandardDispatchOutput,
     )
 
+_is_cpu = is_cpu()
 _is_hip = is_hip()
 _use_aiter = get_bool_env_var("SGLANG_USE_AITER") and _is_hip
+_is_cpu_amx_available = cpu_has_amx_support()
 _is_shuffle_moe_mxfp4 = is_gfx95_supported()
 
 if _is_hip:
@@ -713,6 +723,30 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
             self.w2_weight_triton_tensor = w2_weight
             del layer.w13_weight
             del layer.w2_weight
+        elif _is_cpu and _is_cpu_amx_available:
+            _amx_process_weight_after_loading(layer, ["w13_weight", "w2_weight"])
+            if use_intel_amx_backend(layer):
+                packed_w13_weight_scale = torch.ops.sgl_kernel.convert_scale_packed(
+                    layer.w13_weight_scale
+                )
+                packed_w2_weight_scale = torch.ops.sgl_kernel.convert_scale_packed(
+                    layer.w2_weight_scale
+                )
+                layer.w13_weight_scale = Parameter(
+                    packed_w13_weight_scale, requires_grad=False
+                )
+                layer.w2_weight_scale = Parameter(
+                    packed_w2_weight_scale, requires_grad=False
+                )
+                if hasattr(layer, "w13_weight_bias"):
+                    layer.w13_weight_bias = Parameter(
+                        layer.w13_weight_bias.float(), requires_grad=False
+                    )
+                if hasattr(layer, "w2_weight_bias"):
+                    layer.w2_weight_bias = Parameter(
+                        layer.w2_weight_bias.float(), requires_grad=False
+                    )
+            return
         else:
             from triton_kernels.numerics_details.mxfp import upcast_from_mxfp
 
@@ -772,6 +806,34 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
 
         x = dispatch_output.hidden_states
         topk_output = dispatch_output.topk_output
+
+        if use_intel_amx_backend(layer):
+            from sglang.srt.layers.moe.topk import apply_topk_weights_cpu
+
+            topk_weights, topk_ids, _ = dispatch_output.topk_output
+            x, topk_weights = apply_topk_weights_cpu(
+                self.moe_runner_config.apply_router_weight_on_input, topk_weights, x
+            )
+            output = torch.ops.sgl_kernel.fused_experts_cpu(
+                x,
+                layer.w13_weight,
+                layer.w2_weight,
+                topk_weights,
+                topk_ids,
+                False,  # inplace See [Note] inplace should be False in fused_experts.
+                CPUQuantMethod.MXFP4,
+                layer.w13_weight_scale,  # w1_scale
+                layer.w2_weight_scale,  # w2_scale
+                None,  # w1_zp
+                None,  # w2_zp
+                None,  # block_size
+                getattr(layer, "w13_weight_bias", None),
+                getattr(layer, "w2_weight_bias", None),
+                layer.moe_runner_config.gemm1_alpha,
+                layer.moe_runner_config.gemm1_clamp_limit,
+                True,  # is_vnni
+            )
+            return StandardCombineInput(hidden_states=output)
 
         if self.use_flashinfer:
             # When bf16 mode is enabled, we don't need to quantize the input,

--- a/python/sglang/srt/layers/quantization/unquant.py
+++ b/python/sglang/srt/layers/quantization/unquant.py
@@ -247,6 +247,14 @@ class UnquantizedFusedMoEMethod(FusedMoEMethodBase, MultiPlatformOp):
         # Pack weight for get better performance on CPU
         if _is_cpu and _is_cpu_amx_available:
             _amx_process_weight_after_loading(layer, ["w13_weight", "w2_weight"])
+            if hasattr(layer, "w13_weight_bias"):
+                layer.w13_weight_bias = Parameter(
+                    layer.w13_weight_bias.float(), requires_grad=False
+                )
+            if hasattr(layer, "w2_weight_bias"):
+                layer.w2_weight_bias = Parameter(
+                    layer.w2_weight_bias.float(), requires_grad=False
+                )
 
         # Reorder rows of W1 for fused gated activation
         if self.use_flashinfer_trtllm_moe:
@@ -529,6 +537,10 @@ class UnquantizedFusedMoEMethod(FusedMoEMethodBase, MultiPlatformOp):
                 None,  # w1_zp
                 None,  # w2_zp
                 None,  # block_size
+                getattr(layer, "w13_weight_bias", None),
+                getattr(layer, "w2_weight_bias", None),
+                layer.moe_runner_config.gemm1_alpha,
+                layer.moe_runner_config.gemm1_clamp_limit,
                 True,  # is_vnni
             )
             return StandardCombineInput(hidden_states=output)

--- a/python/sglang/srt/layers/quantization/w8a8_int8.py
+++ b/python/sglang/srt/layers/quantization/w8a8_int8.py
@@ -375,6 +375,10 @@ class W8A8Int8MoEMethod(FusedMoEMethodBase):
                 None,  # w1_zp
                 None,  # w2_zp
                 None,  # block_size
+                None,  # w1 bias
+                None,  # w3 bias
+                None,  # alpha
+                None,  # limit
                 True,  # is_vnni
             )
             return StandardCombineInput(hidden_states=output)

--- a/python/sglang/srt/model_executor/cpu_graph_runner.py
+++ b/python/sglang/srt/model_executor/cpu_graph_runner.py
@@ -263,10 +263,11 @@ def register_fake_ops():
         return mat2.shape[0]
 
     @torch.library.register_fake("sgl_kernel::weight_packed_linear")
-    def _(mat1, mat2, bias, is_vnni):
+    def _(mat1, mat2, bias, is_vnni, out_dtype=None):
         M = mat1.shape[0]
         N = get_n_size(mat2, is_vnni)
-        return mat1.new_empty(M, N)
+        dtype = out_dtype if out_dtype is not None else mat1.dtype
+        return mat1.new_empty(M, N, dtype=dtype)
 
     @torch.library.register_fake("sgl_kernel::per_token_quant_int8_cpu")
     def _(input):

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -533,6 +533,7 @@ class DeepseekV2MoE(nn.Module):
 
         self.shared_experts_is_int8 = False
         self.shared_experts_is_fp8 = False
+        self.shared_experts_is_mxfp4 = False
         self.shared_experts_weight_block_size = None
         # Shared experts: skip when fused into MoE kernel (self.num_fused_shared_experts > 0)
         # or when DeepEP fusion is enabled (shared expert is local slot 16 in FusedMoE, no separate MLP).
@@ -574,6 +575,10 @@ class DeepseekV2MoE(nn.Module):
             self.shared_experts_is_int8 = (
                 not is_packed_weight
                 and self.shared_experts.gate_up_proj.weight.dtype == torch.int8
+            )
+            self.shared_experts_is_mxfp4 = (
+                not is_packed_weight
+                and self.shared_experts.gate_up_proj.weight.dtype == torch.uint8
             )
             self.shared_experts_is_fp8 = (
                 not is_packed_weight
@@ -881,6 +886,7 @@ class DeepseekV2MoE(nn.Module):
             True,  # inplace
             self.shared_experts_is_int8,  # use_int8_w8a8
             self.shared_experts_is_fp8,  # use_fp8_w8a16
+            self.shared_experts_is_mxfp4, # use_mxfp4
             (
                 self.shared_experts.gate_up_proj.weight_scale
                 if self.shared_experts_is_int8

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -769,7 +769,9 @@ class DeepseekV2MoE(nn.Module):
         if hasattr(self, "shared_experts") and use_intel_amx_backend(
             self.shared_experts.gate_up_proj
         ):
-            return self.forward_cpu(hidden_states, should_allreduce_fusion)
+            return self.forward_cpu(
+                hidden_states, should_allreduce_fusion, input_ids_global
+            )
         server_args = get_global_server_args()
         dispatch_info = (
             ExpertLocationDispatchInfo.init_new(layer_id=self.layer_id)
@@ -886,7 +888,7 @@ class DeepseekV2MoE(nn.Module):
             True,  # inplace
             self.shared_experts_is_int8,  # use_int8_w8a8
             self.shared_experts_is_fp8,  # use_fp8_w8a16
-            self.shared_experts_is_mxfp4, # use_mxfp4
+            self.shared_experts_is_mxfp4,  # use_mxfp4
             (
                 self.shared_experts.gate_up_proj.weight_scale
                 if self.shared_experts_is_int8
@@ -910,6 +912,8 @@ class DeepseekV2MoE(nn.Module):
                 if self.shared_experts_is_fp8
                 else None
             ),  # block_size
+            None,  # alpha
+            self.shared_experts.swiglu_limit,  # swiglu_limit
             True,  # is_vnni
         )
         if self.tp_size > 1 and not should_allreduce_fusion:

--- a/sgl-kernel/csrc/cpu/act_quant.cpp
+++ b/sgl-kernel/csrc/cpu/act_quant.cpp
@@ -1,0 +1,185 @@
+#include <ATen/ATen.h>
+#include <ATen/Parallel.h>
+#include <ATen/record_function.h>
+#include <c10/util/Float8_e4m3fn.h>
+#include <torch/all.h>
+
+#include <cmath>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "common.h"
+#include "vec.h"
+
+namespace {
+
+constexpr float kFP8Max = 448.0f;
+constexpr float kFP8Min = -448.0f;
+constexpr float kMinScaleAmax = 1.0e-4f;
+
+template <bool round_scale, typename scalar_t>
+void act_quant_cpu_impl(
+    at::Float8_e4m3fn* __restrict__ y_ptr,
+    float* __restrict__ scale_ptr,
+    const scalar_t* __restrict__ x_ptr,
+    int64_t block_size,
+    int64_t M,
+    int64_t N,
+    int64_t num_groups) {
+
+  const int64_t total_blocks = M * num_groups;
+  at::parallel_for(0, total_blocks, 0, [&](int64_t begin, int64_t end) {
+    int64_t m = 0;
+    int64_t group = 0;
+    data_index_init(begin, m, M, group, num_groups);
+
+    for (int64_t offset = begin; offset < end; ++offset) {
+      const int64_t base = m * N + group * block_size;
+
+      float amax = 0.0f;
+      for (int64_t d = 0; d < block_size; ++d) {
+        amax = std::max(amax, std::abs(static_cast<float>(x_ptr[base + d])));
+      }
+      amax = std::max(amax, kMinScaleAmax);
+
+      float scale_value;
+      if constexpr (round_scale) {
+        scale_value = std::exp2(std::ceil(std::log2(amax / kFP8Max)));
+      } else {
+        scale_value = amax / kFP8Max;
+      }
+      scale_ptr[offset] = scale_value;
+
+      const float inv_scale = 1.0f / scale_value;
+      for (int64_t d = 0; d < block_size; ++d) {
+        float value = static_cast<float>(x_ptr[base + d]) * inv_scale;
+        value = std::min(std::max(value, kFP8Min), kFP8Max);
+        y_ptr[base + d] = at::Float8_e4m3fn(value);
+      }
+
+      data_index_step(m, M, group, num_groups);
+    }
+  });
+}
+
+#if defined(CPU_CAPABILITY_AVX512)
+
+template <bool round_scale>
+void act_quant_cpu_impl(
+    at::Float8_e4m3fn* __restrict__ y_ptr,
+    float* __restrict__ scale_ptr,
+    const at::BFloat16* __restrict__ x_ptr,
+    int64_t block_size,
+    int64_t M,
+    int64_t N,
+    int64_t num_groups) {
+  const int64_t total_blocks = M * num_groups;
+  at::parallel_for(0, total_blocks, 0, [&](int64_t begin, int64_t end) {
+    const __m512 signBit = _mm512_set1_ps(-0.0f);
+    const __m512 vfp8_min = _mm512_set1_ps(kFP8Min);
+    const __m512 vfp8_max = _mm512_set1_ps(kFP8Max);
+
+    int64_t m = 0;
+    int64_t group = 0;
+    data_index_init(begin, m, M, group, num_groups);
+
+    for (int64_t offset = begin; offset < end; ++offset) {
+      const int64_t base = m * N + group * block_size;
+      const at::BFloat16* __restrict__ x_block = x_ptr + base;
+      auto* __restrict__ y_block = y_ptr + base;
+
+      // Phase 1: vectorized absolute max reduction
+      __m512 vamax0 = _mm512_setzero_ps();
+      __m512 vamax1 = _mm512_setzero_ps();
+      int64_t d = 0;
+      for (; d + 32 <= block_size; d += 32) {
+        __m512i raw = _mm512_loadu_si512(reinterpret_cast<const void*>(x_block + d));
+        __m512 v0 = CVT_BF16_TO_FP32(_mm512_extracti32x8_epi32(raw, 0));
+        __m512 v1 = CVT_BF16_TO_FP32(_mm512_extracti32x8_epi32(raw, 1));
+        vamax0 = _mm512_max_ps(vamax0, _mm512_andnot_ps(signBit, v0));
+        vamax1 = _mm512_max_ps(vamax1, _mm512_andnot_ps(signBit, v1));
+      }
+      float amax = _mm512_reduce_max_ps(_mm512_max_ps(vamax0, vamax1));
+      for (; d < block_size; ++d) {
+        amax = std::max(amax, std::abs(static_cast<float>(x_block[d])));
+      }
+      amax = std::max(amax, kMinScaleAmax);
+
+      // Phase 2: compute scale
+      float scale_value;
+      if constexpr (round_scale) {
+        scale_value = std::exp2(std::ceil(std::log2(amax / kFP8Max)));
+      } else {
+        scale_value = amax / kFP8Max;
+      }
+      scale_ptr[offset] = scale_value;
+
+      // Phase 3: vectorized scale + scalar FP8 conversion
+      const float inv_scale = 1.0f / scale_value;
+      const __m512 vinv_scale = _mm512_set1_ps(inv_scale);
+      const __m512 vfp8_min_local = vfp8_min;
+      const __m512 vfp8_max_local = vfp8_max;
+      d = 0;
+      // Use vectorized scaling, then scalar FP8 cast to match reference exactly
+      alignas(64) float scaled_buf[32];
+      for (; d + 32 <= block_size; d += 32) {
+        __m512i raw = _mm512_loadu_si512(reinterpret_cast<const void*>(x_block + d));
+        __m512 v0 = CVT_BF16_TO_FP32(_mm512_extracti32x8_epi32(raw, 0));
+        __m512 v1 = CVT_BF16_TO_FP32(_mm512_extracti32x8_epi32(raw, 1));
+
+        v0 = _mm512_min_ps(_mm512_max_ps(_mm512_mul_ps(v0, vinv_scale), vfp8_min_local), vfp8_max_local);
+        v1 = _mm512_min_ps(_mm512_max_ps(_mm512_mul_ps(v1, vinv_scale), vfp8_min_local), vfp8_max_local);
+
+        _mm512_store_ps(scaled_buf, v0);
+        _mm512_store_ps(scaled_buf + 16, v1);
+
+        for (int64_t i = 0; i < 32; ++i) {
+          y_block[d + i] = at::Float8_e4m3fn(scaled_buf[i]);
+        }
+      }
+      // Scalar remainder
+      for (; d < block_size; ++d) {
+        float value = static_cast<float>(x_block[d]) * inv_scale;
+        value = std::min(std::max(value, kFP8Min), kFP8Max);
+        y_block[d] = at::Float8_e4m3fn(value);
+      }
+
+      data_index_step(m, M, group, num_groups);
+    }
+  });
+}
+
+#endif  // CPU_CAPABILITY_AVX512
+
+}  // namespace
+
+std::tuple<at::Tensor, at::Tensor> act_quant_cpu(
+    at::Tensor& x, int64_t block_size, const std::optional<std::string>& scale_fmt) {
+  CHECK_INPUT(x);
+  TORCH_CHECK(x.dim() >= 1, "x must have at least 1 dimension");
+  TORCH_CHECK(block_size > 0, "block_size must be positive");
+
+  const int64_t N = x.size(-1);
+  TORCH_CHECK(N % block_size == 0, "Last dimension size must be divisible by block_size");
+
+  const int64_t M = x.numel() / N;
+  const int64_t num_groups = N / block_size;
+
+  at::Tensor y = at::empty_like(x, x.options().dtype(at::kFloat8_e4m3fn));
+
+  std::vector<int64_t> scale_sizes = x.sizes().vec();
+  scale_sizes.back() = num_groups;
+  at::Tensor scale = at::empty(scale_sizes, x.options().dtype(at::kFloat));
+
+  const bool round_scale = scale_fmt.has_value();
+  CPU_DISPATCH_FLOATING_TYPES(x.scalar_type(), "act_quant_cpu", [&] {
+    if (round_scale) {
+      act_quant_cpu_impl<true>(y.data_ptr<at::Float8_e4m3fn>(), scale.data_ptr<float>(), x.data_ptr<scalar_t>(), block_size, M, N, num_groups);
+    } else {
+      act_quant_cpu_impl<false>(y.data_ptr<at::Float8_e4m3fn>(), scale.data_ptr<float>(), x.data_ptr<scalar_t>(), block_size, M, N, num_groups);
+    }
+  });
+
+  return {y, scale};
+}

--- a/sgl-kernel/csrc/cpu/allocator.cpp
+++ b/sgl-kernel/csrc/cpu/allocator.cpp
@@ -1,0 +1,229 @@
+#include "common.h"
+
+namespace {
+
+inline int64_t ceil_div(int64_t a, int64_t b) {
+  return (a + b - 1) / b;
+}
+
+// Ensure tensor is of the given dtype and contiguous, avoiding copy when already matching.
+inline at::Tensor as_dtype(at::Tensor& t, at::ScalarType dtype) {
+  if (t.scalar_type() == dtype && t.is_contiguous()) return t;
+  return t.to(dtype).contiguous();
+}
+
+// Check if tensor is of given dtype and contiguous
+inline bool is_dtype_contig(const at::Tensor& t, at::ScalarType dtype) {
+  return t.scalar_type() == dtype && t.is_contiguous();
+}
+
+// ---------------------------------------------------------------------------
+// alloc_extend_kernel_impl: templated on input type, always writes int64 output
+// ---------------------------------------------------------------------------
+template <typename in_t>
+void alloc_extend_kernel_impl(
+    const in_t* pre_lens_ptr,
+    const in_t* seq_lens_ptr,
+    const in_t* last_loc_ptr,
+    const in_t* free_pages_ptr,
+    int64_t* out_ptr,
+    int64_t bs,
+    int64_t page_size) {
+  std::vector<int64_t> extend_lens(bs);
+  std::vector<int64_t> output_start(bs);
+  std::vector<int64_t> num_new_pages_vec(bs);
+  std::vector<int64_t> new_page_start(bs);
+
+  int64_t extend_cumsum = 0;
+  int64_t page_cumsum = 0;
+  for (int64_t i = 0; i < bs; ++i) {
+    int64_t pre_len = static_cast<int64_t>(pre_lens_ptr[i]);
+    int64_t seq_len = static_cast<int64_t>(seq_lens_ptr[i]);
+    int64_t ext_len = seq_len - pre_len;
+    extend_lens[i] = ext_len;
+
+    output_start[i] = extend_cumsum;
+    extend_cumsum += ext_len;
+
+    int64_t pages_after = ceil_div(seq_len, page_size);
+    int64_t pages_before = ceil_div(pre_len, page_size);
+    int64_t new_pages = pages_after - pages_before;
+    num_new_pages_vec[i] = new_pages;
+
+    new_page_start[i] = page_cumsum;
+    page_cumsum += new_pages;
+  }
+
+  at::parallel_for(0, bs, 1, [&](int64_t begin, int64_t end) {
+    for (int64_t i = begin; i < end; ++i) {
+      const int64_t pre_len = static_cast<int64_t>(pre_lens_ptr[i]);
+      const int64_t seq_len = static_cast<int64_t>(seq_lens_ptr[i]);
+      const int64_t ext_len = extend_lens[i];
+      if (ext_len == 0) continue;
+
+      const int64_t out_start = output_start[i];
+      const int64_t pg_start = new_page_start[i];
+      const int64_t num_new_pages_self = num_new_pages_vec[i];
+      const int64_t last_loc_i = static_cast<int64_t>(last_loc_ptr[i]);
+      int64_t* out = out_ptr + out_start;
+
+      // Part 1: fill the old partial page
+      const int64_t page_boundary = ceil_div(pre_len, page_size) * page_size;
+      const int64_t num_part1 = std::min(seq_len, page_boundary) - pre_len;
+      for (int64_t j = 0; j < num_part1; ++j) {
+        out[j] = last_loc_i + 1 + j;
+      }
+
+      if (pre_len + num_part1 == seq_len) continue;
+
+      // Part 2: fill new full pages
+      const int64_t full_page_start = ceil_div(pre_len, page_size) * page_size;
+      const int64_t full_page_end = (seq_len / page_size) * page_size;
+      const int64_t num_part2 = full_page_end - full_page_start;
+      if (num_part2 > 0) {
+        int64_t* out2 = out + num_part1;
+        for (int64_t j = 0; j < num_part2; ++j) {
+          int64_t page_idx = j / page_size;
+          int64_t in_page_off = j % page_size;
+          out2[j] = static_cast<int64_t>(free_pages_ptr[pg_start + page_idx]) * page_size + in_page_off;
+        }
+      }
+
+      if (pre_len + num_part1 + num_part2 == seq_len) continue;
+
+      // Part 3: fill the new partial page at the end
+      const int64_t num_part3 = seq_len - (seq_len / page_size) * page_size;
+      if (num_part3 > 0) {
+        int64_t start_page = static_cast<int64_t>(free_pages_ptr[pg_start + num_new_pages_self - 1]);
+        int64_t* out3 = out + num_part1 + num_part2;
+        for (int64_t j = 0; j < num_part3; ++j) {
+          out3[j] = start_page * page_size + j;
+        }
+      }
+    }
+  });
+}
+
+// ---------------------------------------------------------------------------
+// alloc_decode_kernel_impl: templated on input type, always writes int64 output
+// ---------------------------------------------------------------------------
+template <typename in_t>
+void alloc_decode_kernel_impl(
+    const in_t* seq_lens_ptr,
+    const in_t* last_loc_ptr,
+    const in_t* free_pages_ptr,
+    int64_t* out_ptr,
+    int64_t bs,
+    int64_t page_size) {
+  std::vector<int64_t> num_new_pages_vec(bs);
+  std::vector<int64_t> new_page_start(bs);
+
+  int64_t page_cumsum = 0;
+  for (int64_t i = 0; i < bs; ++i) {
+    int64_t seq_len = static_cast<int64_t>(seq_lens_ptr[i]);
+    int64_t pre_len = seq_len - 1;
+    int64_t pages_after = ceil_div(seq_len, page_size);
+    int64_t pages_before = ceil_div(pre_len, page_size);
+    int64_t new_pages = pages_after - pages_before;
+    num_new_pages_vec[i] = new_pages;
+    new_page_start[i] = page_cumsum;
+    page_cumsum += new_pages;
+  }
+
+  at::parallel_for(0, bs, 1, [&](int64_t begin, int64_t end) {
+    for (int64_t i = begin; i < end; ++i) {
+      if (num_new_pages_vec[i] == 0) {
+        out_ptr[i] = static_cast<int64_t>(last_loc_ptr[i]) + 1;
+      } else {
+        int64_t page = static_cast<int64_t>(free_pages_ptr[new_page_start[i]]);
+        out_ptr[i] = page * page_size;
+      }
+    }
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Prepare output buffer: always int64, reuse tensor if already int64+contiguous
+// ---------------------------------------------------------------------------
+inline std::pair<int64_t*, at::Tensor> prepare_out_i64(at::Tensor& out_indices) {
+  if (out_indices.scalar_type() == at::kLong && out_indices.is_contiguous()) {
+    return {out_indices.data_ptr<int64_t>(), at::Tensor()};
+  }
+  auto buf = at::empty({out_indices.numel()}, out_indices.options().dtype(at::kLong));
+  return {buf.data_ptr<int64_t>(), buf};
+}
+
+inline void copy_back_if_needed(at::Tensor& out_indices, const at::Tensor& buf) {
+  if (buf.defined()) {
+    out_indices.copy_(buf);
+  }
+}
+
+} // anonymous namespace
+
+// ============================================================================
+// alloc_extend_kernel_cpu
+// ============================================================================
+void alloc_extend_kernel_cpu(
+    at::Tensor& pre_lens,
+    at::Tensor& seq_lens,
+    at::Tensor& last_loc,
+    at::Tensor& free_pages,
+    at::Tensor& out_indices,
+    int64_t page_size) {
+  const int64_t bs = pre_lens.size(0);
+  auto [out_ptr, out_buf] = prepare_out_i64(out_indices);
+
+  if (pre_lens.scalar_type() == at::kInt) {
+    auto pl = as_dtype(pre_lens, at::kInt);
+    auto sl = as_dtype(seq_lens, at::kInt);
+    auto ll = as_dtype(last_loc, at::kInt);
+    auto fp = as_dtype(free_pages, at::kInt);
+    alloc_extend_kernel_impl<int32_t>(
+        pl.data_ptr<int32_t>(), sl.data_ptr<int32_t>(),
+        ll.data_ptr<int32_t>(), fp.data_ptr<int32_t>(),
+        out_ptr, bs, page_size);
+  } else {
+    auto pl = as_dtype(pre_lens, at::kLong);
+    auto sl = as_dtype(seq_lens, at::kLong);
+    auto ll = as_dtype(last_loc, at::kLong);
+    auto fp = as_dtype(free_pages, at::kLong);
+    alloc_extend_kernel_impl<int64_t>(
+        pl.data_ptr<int64_t>(), sl.data_ptr<int64_t>(),
+        ll.data_ptr<int64_t>(), fp.data_ptr<int64_t>(),
+        out_ptr, bs, page_size);
+  }
+
+  copy_back_if_needed(out_indices, out_buf);
+}
+
+// ============================================================================
+// alloc_decode_kernel_cpu
+// ============================================================================
+void alloc_decode_kernel_cpu(
+    at::Tensor& seq_lens,
+    at::Tensor& last_loc,
+    at::Tensor& free_pages,
+    at::Tensor& out_indices,
+    int64_t page_size) {
+  const int64_t bs = seq_lens.size(0);
+  auto [out_ptr, out_buf] = prepare_out_i64(out_indices);
+
+  if (seq_lens.scalar_type() == at::kInt) {
+    auto sl = as_dtype(seq_lens, at::kInt);
+    auto ll = as_dtype(last_loc, at::kInt);
+    auto fp = as_dtype(free_pages, at::kInt);
+    alloc_decode_kernel_impl<int32_t>(
+        sl.data_ptr<int32_t>(), ll.data_ptr<int32_t>(),
+        fp.data_ptr<int32_t>(), out_ptr, bs, page_size);
+  } else {
+    auto sl = as_dtype(seq_lens, at::kLong);
+    auto ll = as_dtype(last_loc, at::kLong);
+    auto fp = as_dtype(free_pages, at::kLong);
+    alloc_decode_kernel_impl<int64_t>(
+        sl.data_ptr<int64_t>(), ll.data_ptr<int64_t>(),
+        fp.data_ptr<int64_t>(), out_ptr, bs, page_size);
+  }
+
+  copy_back_if_needed(out_indices, out_buf);
+}

--- a/sgl-kernel/csrc/cpu/common.h
+++ b/sgl-kernel/csrc/cpu/common.h
@@ -343,6 +343,13 @@ inline int get_cache_blocks<at::Float8_e4m3fn>(int chunk_size) {
   return std::min(MAX_CACHE_BLOCK_SIZE, cache_block_size);
 }
 
+template <>
+inline int get_cache_blocks<uint8_t>(int chunk_size) {
+  // mxfp4 uses bf16 as accumulate type
+  int cache_block_size = get_cache_blocks<at::BFloat16>(chunk_size);
+  return std::min(MAX_CACHE_BLOCK_SIZE, cache_block_size);
+}
+
 // 2d sequential loop in range : [mb0, mb1), [nb0, nb1)
 template <typename T, typename func_t>
 inline void loop_2d(int64_t mb0, int64_t mb1, int64_t nb0, int64_t nb1, int64_t chunk_size, const func_t& f) {

--- a/sgl-kernel/csrc/cpu/common.h
+++ b/sgl-kernel/csrc/cpu/common.h
@@ -73,6 +73,28 @@ namespace {
     }                                                            \
   }()
 
+// dispatch: float, bfloat16, float16
+#define CPU_DISPATCH_FLOATING_TYPES(TYPE, NAME, ...)              \
+  [&] {                                                          \
+    switch (TYPE) {                                              \
+      case at::ScalarType::Float: {                              \
+        using scalar_t = float;                                  \
+        return __VA_ARGS__();                                    \
+      }                                                          \
+      case at::ScalarType::BFloat16: {                           \
+        using scalar_t = at::BFloat16;                           \
+        return __VA_ARGS__();                                    \
+      }                                                          \
+      case at::ScalarType::Half: {                               \
+        using scalar_t = at::Half;                               \
+        return __VA_ARGS__();                                    \
+      }                                                          \
+      default:                                                   \
+        TORCH_CHECK(false, NAME, ": unsupported dtype ",         \
+                    toString(TYPE));                              \
+    }                                                            \
+  }()
+
 // Helper MICRO for CPU_DISPATCH_FLOATING_TYPES_EXT:
 //   TYPE1: the primary dtype (input, output, weight);
 //   TYPE2: defined as PARAM_T input

--- a/sgl-kernel/csrc/cpu/compressor.cpp
+++ b/sgl-kernel/csrc/cpu/compressor.cpp
@@ -1,0 +1,462 @@
+#include "common.h"
+#include "vec.h"
+
+#include <cmath>
+#include <algorithm>
+#include <vector>
+
+namespace {
+
+using fVec = at::vec::Vectorized<float>;
+
+// ──────────────────────────── helpers ────────────────────────────
+
+static inline int64_t compute_state_len(int64_t seq_len, int64_t ratio) {
+  return seq_len % ratio + (ratio == 4 ? ratio : 0);
+}
+
+// In-place RMS norm on a single row of float data with weight.
+static inline void rmsnorm_row(
+    float* __restrict__ out,
+    const float* __restrict__ input,
+    const float* __restrict__ weight,
+    int64_t dim,
+    float eps) {
+  float sum_sq = 0.0f;
+  int64_t d = 0;
+#if defined(CPU_CAPABILITY_AVX512)
+  fVec sum_v(0.0f);
+  for (; d <= dim - fVec::size(); d += fVec::size()) {
+    fVec x = fVec::loadu(input + d);
+    sum_v = sum_v + x * x;
+  }
+  sum_sq = vec_reduce_sum(sum_v);
+#endif
+  for (; d < dim; ++d) {
+    sum_sq += input[d] * input[d];
+  }
+  float rsqrt_var = 1.0f / std::sqrt(sum_sq / dim + eps);
+
+  d = 0;
+#if defined(CPU_CAPABILITY_AVX512)
+  fVec scale_v(rsqrt_var);
+  for (; d <= dim - fVec::size(); d += fVec::size()) {
+    fVec x = fVec::loadu(input + d);
+    fVec w = fVec::loadu(weight + d);
+    (x * scale_v * w).store(out + d);
+  }
+#endif
+  for (; d < dim; ++d) {
+    out[d] = input[d] * rsqrt_var * weight[d];
+  }
+}
+
+// In-place interleaved rotary embedding on a single row.
+// freqs is [rope_dim] float, x is [rope_dim] float.
+static inline void apply_rotary_emb_row_f32(
+    float* __restrict__ x,
+    const float* __restrict__ freqs,
+    int64_t rope_dim,
+    bool inverse) {
+  int64_t k = 0;
+#if defined(CPU_CAPABILITY_AVX512)
+  // Build sign mask for complex multiply
+  __m512 sign_mask;
+  if (inverse) {
+    sign_mask = _mm512_castsi512_ps(_mm512_set_epi32(
+        (int)0x80000000, 0, (int)0x80000000, 0,
+        (int)0x80000000, 0, (int)0x80000000, 0,
+        (int)0x80000000, 0, (int)0x80000000, 0,
+        (int)0x80000000, 0, (int)0x80000000, 0));
+  } else {
+    sign_mask = _mm512_castsi512_ps(_mm512_set_epi32(
+        0, (int)0x80000000, 0, (int)0x80000000,
+        0, (int)0x80000000, 0, (int)0x80000000,
+        0, (int)0x80000000, 0, (int)0x80000000,
+        0, (int)0x80000000, 0, (int)0x80000000));
+  }
+  for (; k <= rope_dim - 16; k += 16) {
+    __m512 xv = _mm512_loadu_ps(x + k);
+    __m512 fv = _mm512_loadu_ps(freqs + k);
+    __m512 out = _mm512_fmadd_ps(
+        xv,
+        _mm512_permute_ps(fv, 0xA0),
+        _mm512_mul_ps(
+            _mm512_permute_ps(xv, 0xB1),
+            _mm512_xor_ps(_mm512_permute_ps(fv, 0xF5), sign_mask)));
+    _mm512_storeu_ps(x + k, out);
+  }
+#endif
+  for (; k < rope_dim; k += 2) {
+    float xr = x[k], xi = x[k + 1];
+    float cr = freqs[k], ci = freqs[k + 1];
+    if (inverse) {
+      x[k]     = xr * cr + xi * ci;
+      x[k + 1] = xi * cr - xr * ci;
+    } else {
+      x[k]     = xr * cr - xi * ci;
+      x[k + 1] = xr * ci + xi * cr;
+    }
+  }
+}
+
+// Hadamard transform for rotate_activation.
+// Operates on float buffer of power-of-2 size.
+static void hadamard_transform_row(float* __restrict__ data, int64_t n, float scale) {
+  if (n == 1) {
+    data[0] *= scale;
+    return;
+  }
+#if defined(CPU_CAPABILITY_AVX512)
+  if (n >= 16) {
+    // Phase 1: fused butterflies for h=1,2,4,8
+    for (int64_t j = 0; j < n; j += 16) {
+      __m512 v = _mm512_loadu_ps(data + j);
+      __m512 p, s, d;
+      // h=1
+      p = _mm512_permute_ps(v, 0b10'11'00'01);
+      s = _mm512_add_ps(v, p); d = _mm512_sub_ps(p, v);
+      v = _mm512_mask_blend_ps((__mmask16)0xAAAA, s, d);
+      // h=2
+      p = _mm512_permute_ps(v, 0b01'00'11'10);
+      s = _mm512_add_ps(v, p); d = _mm512_sub_ps(p, v);
+      v = _mm512_mask_blend_ps((__mmask16)0xCCCC, s, d);
+      // h=4
+      p = _mm512_permutexvar_ps(
+          _mm512_set_epi32(11,10,9,8, 15,14,13,12, 3,2,1,0, 7,6,5,4), v);
+      s = _mm512_add_ps(v, p); d = _mm512_sub_ps(p, v);
+      v = _mm512_mask_blend_ps((__mmask16)0xF0F0, s, d);
+      // h=8
+      p = _mm512_permutexvar_ps(
+          _mm512_set_epi32(7,6,5,4, 3,2,1,0, 15,14,13,12, 11,10,9,8), v);
+      s = _mm512_add_ps(v, p); d = _mm512_sub_ps(p, v);
+      v = _mm512_mask_blend_ps((__mmask16)0xFF00, s, d);
+      _mm512_storeu_ps(data + j, v);
+    }
+    // Phase 2: larger butterflies
+    for (int64_t h = 16; h < n; h <<= 1) {
+      for (int64_t j = 0; j < n; j += 2 * h) {
+        for (int64_t k = 0; k < h; k += 16) {
+          __m512 a = _mm512_loadu_ps(data + j + k);
+          __m512 b = _mm512_loadu_ps(data + j + k + h);
+          _mm512_storeu_ps(data + j + k, _mm512_add_ps(a, b));
+          _mm512_storeu_ps(data + j + k + h, _mm512_sub_ps(a, b));
+        }
+      }
+    }
+    // Apply scale
+    __m512 sv = _mm512_set1_ps(scale);
+    for (int64_t j = 0; j < n; j += 16) {
+      __m512 v = _mm512_loadu_ps(data + j);
+      _mm512_storeu_ps(data + j, _mm512_mul_ps(v, sv));
+    }
+    return;
+  }
+#endif
+  // Scalar fallback
+  int64_t h = 1;
+  while (h < n) {
+    for (int64_t j = 0; j < n; j += 2 * h) {
+      for (int64_t k = 0; k < h; ++k) {
+        float a = data[j + k], b = data[j + k + h];
+        data[j + k]     = a + b;
+        data[j + k + h] = a - b;
+      }
+    }
+    h <<= 1;
+  }
+  for (int64_t j = 0; j < n; ++j) {
+    data[j] *= scale;
+  }
+}
+
+// overlap_transform_decode: tensor [bs, 2*ratio, 2*head_dim] -> [bs, 2*ratio, head_dim]
+// ret[:, :r, :] = tensor[:, :r, :d]
+// ret[:, r:, :] = tensor[:, r:, d:]
+// where r = ratio, d = head_dim
+static void overlap_transform_decode_inplace(
+    float* __restrict__ out,  // [n_items, head_dim]
+    const float* __restrict__ in,  // [n_items, 2*head_dim]
+    int64_t ratio,
+    int64_t head_dim) {
+  // First half: copy in[:ratio, :head_dim]
+  for (int64_t i = 0; i < ratio; ++i) {
+    const float* src = in + i * 2 * head_dim;
+    float* dst = out + i * head_dim;
+    std::memcpy(dst, src, head_dim * sizeof(float));
+  }
+  // Second half: copy in[ratio:2*ratio, head_dim:2*head_dim]
+  for (int64_t i = ratio; i < 2 * ratio; ++i) {
+    const float* src = in + i * 2 * head_dim + head_dim;
+    float* dst = out + i * head_dim;
+    std::memcpy(dst, src, head_dim * sizeof(float));
+  }
+}
+
+// ──────────────────── compress_decode_cpu ────────────────────
+
+// Equivalent to compress_decode_old in Python.
+// pool_kv/pool_score: [max_reqs, state_len, coff*head_dim]
+// kv/score: [bs, coff*head_dim]
+// seq_lens: [bs] int64
+// req_pool_indices: [bs] int64
+// ape: [ratio, coff*head_dim] float32
+// norm_weight: [head_dim] float32
+// freqs_cis: [max_seq, rope_dim] float32 (real-valued interleaved cos/sin)
+void compress_decode_cpu_impl(
+    float* __restrict__ pool_kv,
+    float* __restrict__ pool_score,
+    const float* __restrict__ kv,
+    const float* __restrict__ score,
+    const int64_t* __restrict__ seq_lens,
+    const int64_t* __restrict__ req_pool_indices,
+    const float* __restrict__ ape,
+    const float* __restrict__ norm_weight,
+    const float* __restrict__ freqs_cis,
+    float* __restrict__ output,  // [bs, head_dim]
+    int64_t bs,
+    int64_t pool_state_len,
+    int64_t pool_row_stride,  // stride between rows in pool (may be > coff_hd for interleaved storage)
+    int64_t kv_row_stride,    // stride between rows in kv/score input
+    int64_t ratio,
+    int64_t head_dim,
+    int64_t rope_head_dim,
+    int64_t coff,
+    bool overlap,
+    bool rotate,
+    float norm_eps,
+    int64_t freqs_stride) {
+
+  int64_t coff_hd = coff * head_dim;
+
+  at::parallel_for(0, bs, 1, [&](int64_t begin, int64_t end) {
+    // Scratch buffers per thread
+    std::vector<float> kv_buf(ratio * coff * coff_hd);
+    std::vector<float> score_buf(ratio * coff * coff_hd);
+    std::vector<float> kv_work(ratio * coff * head_dim);
+    std::vector<float> score_work(ratio * coff * head_dim);
+    std::vector<float> compressed(head_dim);
+
+    for (int64_t b = begin; b < end; ++b) {
+      int64_t seq_len = seq_lens[b];
+      int64_t req_idx = req_pool_indices[b];
+      int64_t write_pos = (seq_len - 1) % ratio + (overlap ? ratio : 0);
+
+      float* pool_kv_req = pool_kv + req_idx * pool_state_len * pool_row_stride;
+      float* pool_score_req = pool_score + req_idx * pool_state_len * pool_row_stride;
+
+      // Write new kv and score to pool at write_pos
+      std::memcpy(pool_kv_req + write_pos * pool_row_stride, kv + b * kv_row_stride, coff_hd * sizeof(float));
+      std::memcpy(pool_score_req + write_pos * pool_row_stride, score + b * kv_row_stride, coff_hd * sizeof(float));
+
+      // Copy out entire pool state for this request (strided -> contiguous)
+      int64_t total_state = ratio * coff;
+      for (int64_t r = 0; r < total_state; ++r) {
+        std::memcpy(kv_buf.data() + r * coff_hd, pool_kv_req + r * pool_row_stride, coff_hd * sizeof(float));
+        std::memcpy(score_buf.data() + r * coff_hd, pool_score_req + r * pool_row_stride, coff_hd * sizeof(float));
+      }
+
+      // Handle overlap shift
+      if (overlap && (seq_len % ratio == 0)) {
+        // Shift: pool[:ratio] = pool[ratio:2*ratio]
+        for (int64_t r = 0; r < ratio; ++r) {
+          std::memcpy(pool_kv_req + r * pool_row_stride,
+                      pool_kv_req + (ratio + r) * pool_row_stride,
+                      coff_hd * sizeof(float));
+          std::memcpy(pool_score_req + r * pool_row_stride,
+                      pool_score_req + (ratio + r) * pool_row_stride,
+                      coff_hd * sizeof(float));
+        }
+      }
+
+      // Add APE to score
+      // kv_buf/score_buf shape: [coff, ratio, coff_hd] (after reshape from [total_state, coff_hd])
+      // APE shape: [ratio, coff_hd]
+      for (int64_t c = 0; c < coff; ++c) {
+        for (int64_t r = 0; r < ratio; ++r) {
+          float* sp = score_buf.data() + (c * ratio + r) * coff_hd;
+          const float* ap = ape + r * coff_hd;
+          int64_t d = 0;
+#if defined(CPU_CAPABILITY_AVX512)
+          for (; d <= coff_hd - 16; d += 16) {
+            __m512 sv = _mm512_loadu_ps(sp + d);
+            __m512 av = _mm512_loadu_ps(ap + d);
+            _mm512_storeu_ps(sp + d, _mm512_add_ps(sv, av));
+          }
+#endif
+          for (; d < coff_hd; ++d) {
+            sp[d] += ap[d];
+          }
+        }
+      }
+
+      if (overlap) {
+        // overlap_transform_decode on kv and score
+        // Input: [bs=1, coff*ratio=2*ratio, coff*head_dim=2*head_dim]
+        // Output: [bs=1, 2*ratio, head_dim]
+        overlap_transform_decode_inplace(kv_work.data(), kv_buf.data(), ratio, head_dim);
+        overlap_transform_decode_inplace(score_work.data(), score_buf.data(), ratio, head_dim);
+      } else {
+        // Just copy, treating as [ratio, head_dim]
+        for (int64_t r = 0; r < ratio; ++r) {
+          std::memcpy(kv_work.data() + r * head_dim, kv_buf.data() + r * coff_hd, head_dim * sizeof(float));
+          std::memcpy(score_work.data() + r * head_dim, score_buf.data() + r * coff_hd, head_dim * sizeof(float));
+        }
+      }
+
+      // Now: kv_work, score_work are [ratio*coff, head_dim]
+      int64_t compress_rows = ratio * coff;
+
+      // Row-major vectorized softmax + weighted sum
+      // 1) Find per-column max across rows
+      std::memcpy(compressed.data(), score_work.data(), head_dim * sizeof(float));
+      for (int64_t r = 1; r < compress_rows; ++r) {
+        const float* sr = score_work.data() + r * head_dim;
+        int64_t d = 0;
+#if defined(CPU_CAPABILITY_AVX512)
+        for (; d <= head_dim - 16; d += 16) {
+          __m512 mx = _mm512_loadu_ps(compressed.data() + d);
+          __m512 sv = _mm512_loadu_ps(sr + d);
+          _mm512_storeu_ps(compressed.data() + d, _mm512_max_ps(mx, sv));
+        }
+#endif
+        for (; d < head_dim; ++d) {
+          compressed[d] = std::max(compressed[d], sr[d]);
+        }
+      }
+      // 2) Compute exp(score - max) in-place in score_work, accumulate sum
+      // Use kv_buf as sum accumulator (reuse buffer, head_dim <= kv_buf size)
+      float* sum_buf = kv_buf.data();  // reuse, only need head_dim floats
+      std::memset(sum_buf, 0, head_dim * sizeof(float));
+      for (int64_t r = 0; r < compress_rows; ++r) {
+        float* sr = score_work.data() + r * head_dim;
+        int64_t d = 0;
+#if defined(CPU_CAPABILITY_AVX512)
+        for (; d <= head_dim - 16; d += 16) {
+          fVec diff_v = fVec::loadu(sr + d) - fVec::loadu(compressed.data() + d);
+          fVec exp_v = diff_v.exp();
+          exp_v.store(sr + d);
+          __m512 sm = _mm512_loadu_ps(sum_buf + d);
+          _mm512_storeu_ps(sum_buf + d, _mm512_add_ps(sm, (__m512)exp_v));
+        }
+#endif
+        for (; d < head_dim; ++d) {
+          sr[d] = std::exp(sr[d] - compressed[d]);
+          sum_buf[d] += sr[d];
+        }
+      }
+      // 3) Pre-compute inv_sum, then weighted sum with division fused
+      // Compute inv_sum = 1/sum in-place in sum_buf
+      {
+        int64_t d = 0;
+#if defined(CPU_CAPABILITY_AVX512)
+        for (; d <= head_dim - 16; d += 16) {
+          __m512 sm = _mm512_loadu_ps(sum_buf + d);
+          _mm512_storeu_ps(sum_buf + d, _mm512_rcp14_ps(sm));
+        }
+#endif
+        for (; d < head_dim; ++d) {
+          sum_buf[d] = 1.0f / sum_buf[d];
+        }
+      }
+      std::memset(compressed.data(), 0, head_dim * sizeof(float));
+      for (int64_t r = 0; r < compress_rows; ++r) {
+        const float* kr = kv_work.data() + r * head_dim;
+        const float* sr = score_work.data() + r * head_dim;
+        int64_t d = 0;
+#if defined(CPU_CAPABILITY_AVX512)
+        for (; d <= head_dim - 16; d += 16) {
+          __m512 kv = _mm512_loadu_ps(kr + d);
+          __m512 sw = _mm512_mul_ps(_mm512_loadu_ps(sr + d), _mm512_loadu_ps(sum_buf + d));
+          __m512 acc = _mm512_loadu_ps(compressed.data() + d);
+          _mm512_storeu_ps(compressed.data() + d, _mm512_fmadd_ps(kv, sw, acc));
+        }
+#endif
+        for (; d < head_dim; ++d) {
+          compressed[d] += kr[d] * sr[d] * sum_buf[d];
+        }
+      }
+
+      // RMS norm with weight
+      rmsnorm_row(output + b * head_dim, compressed.data(), norm_weight, head_dim, norm_eps);
+
+      // Apply rotary embedding to last rope_head_dim elements
+      int64_t freq_pos = (seq_len - 1) / ratio * ratio;
+      const float* freq_ptr = freqs_cis + freq_pos * freqs_stride;
+      apply_rotary_emb_row_f32(
+          output + b * head_dim + (head_dim - rope_head_dim),
+          freq_ptr,
+          rope_head_dim,
+          false);
+
+      // Optional rotate (Hadamard transform)
+      if (rotate) {
+        float scale = 1.0f / std::sqrt((float)head_dim);
+        hadamard_transform_row(output + b * head_dim, head_dim, scale);
+      }
+    }
+  });
+}
+
+}  // anonymous namespace
+
+at::Tensor compress_decode_cpu(
+    at::Tensor& pool_kv,
+    at::Tensor& pool_score,
+    at::Tensor& kv,
+    at::Tensor& score,
+    at::Tensor& seq_lens,
+    at::Tensor& req_pool_indices,
+    at::Tensor& ape,
+    at::Tensor& norm_weight,
+    at::Tensor& freqs_cis,
+    int64_t ratio,
+    int64_t head_dim,
+    int64_t rope_head_dim,
+    bool overlap,
+    bool rotate,
+    double norm_eps) {
+  int64_t bs = kv.size(0);
+  int64_t coff = 1 + (overlap ? 1 : 0);
+  int64_t pool_state_len = pool_kv.size(1);
+
+  // Ensure float32
+  TORCH_CHECK(kv.scalar_type() == at::kFloat, "compress_decode_cpu: kv must be float32");
+  TORCH_CHECK(score.scalar_type() == at::kFloat, "compress_decode_cpu: score must be float32");
+  TORCH_CHECK(pool_kv.scalar_type() == at::kFloat, "compress_decode_cpu: pool_kv must be float32");
+
+  at::Tensor output = at::empty({bs, head_dim}, kv.options());
+
+  // freqs_cis stride: number of elements per position
+  int64_t freqs_stride = freqs_cis.size(-1);
+  // Pool row stride (may be > coff_hd if pool is a non-contiguous view)
+  int64_t pool_row_stride = pool_kv.stride(-2);
+  // kv/score row stride
+  int64_t kv_row_stride = kv.stride(0);
+
+  compress_decode_cpu_impl(
+      pool_kv.data_ptr<float>(),
+      pool_score.data_ptr<float>(),
+      kv.data_ptr<float>(),
+      score.data_ptr<float>(),
+      seq_lens.data_ptr<int64_t>(),
+      req_pool_indices.data_ptr<int64_t>(),
+      ape.data_ptr<float>(),
+      norm_weight.data_ptr<float>(),
+      freqs_cis.data_ptr<float>(),
+      output.data_ptr<float>(),
+      bs,
+      pool_state_len,
+      pool_row_stride,
+      kv_row_stride,
+      ratio,
+      head_dim,
+      rope_head_dim,
+      coff,
+      overlap,
+      rotate,
+      static_cast<float>(norm_eps),
+      freqs_stride);
+
+  return output;
+}

--- a/sgl-kernel/csrc/cpu/fused_scale.cpp
+++ b/sgl-kernel/csrc/cpu/fused_scale.cpp
@@ -1,0 +1,57 @@
+#include <ATen/ATen.h>
+#include <ATen/Parallel.h>
+#include <ATen/record_function.h>
+#include <torch/all.h>
+
+#include <vector>
+
+#include "common.h"
+
+namespace {
+
+template <typename out_t, typename weight_t, typename scale_t>
+void fused_scale_cpu_impl(
+    at::Tensor& out,
+    const at::Tensor& weight,
+    const at::Tensor& q_scale,
+    double out_scale,
+    int64_t numel) {
+  const weight_t* __restrict__ weight_ptr = weight.const_data_ptr<weight_t>();
+  const scale_t* __restrict__ q_scale_ptr = q_scale.const_data_ptr<scale_t>();
+  out_t* __restrict__ out_ptr = out.mutable_data_ptr<out_t>();
+  const float out_scale_f = static_cast<float>(out_scale);
+
+  at::parallel_for(0, numel, GRAIN_SIZE, [&](int64_t begin, int64_t end) {
+    for (int64_t i = begin; i < end; ++i) {
+      const float value = static_cast<float>(weight_ptr[i]) * out_scale_f * static_cast<float>(q_scale_ptr[i]);
+      out_ptr[i] = static_cast<out_t>(value);
+    }
+  });
+}
+
+}  // namespace
+
+at::Tensor fused_scale_cpu(at::Tensor& weight, double out_scale, at::Tensor& q_scale) {
+  RECORD_FUNCTION("sgl-kernel::fused_scale_cpu", std::vector<c10::IValue>({weight, q_scale}));
+
+  CHECK_INPUT(weight);
+  CHECK_INPUT(q_scale);
+  CHECK_DIM(2, weight);
+  TORCH_CHECK(q_scale.numel() == weight.numel(), "q_scale must have the same number of elements as weight");
+  TORCH_CHECK(
+      weight.scalar_type() == at::kFloat || weight.scalar_type() == at::kHalf || weight.scalar_type() == at::kBFloat16,
+      "weight must be float32, float16, or bfloat16");
+  TORCH_CHECK(q_scale.scalar_type() == at::kFloat, "q_scale must be float32");
+
+  const int64_t B = weight.size(0);
+  const int64_t H = weight.size(1);
+  const int64_t numel = B * H;
+  at::Tensor out = at::empty({B, H, 1}, weight.options().dtype(at::kFloat));
+
+  AT_DISPATCH_FLOATING_TYPES_AND2(
+      at::kHalf, at::kBFloat16, weight.scalar_type(), "fused_scale_cpu_weight", [&] {
+        fused_scale_cpu_impl<float, scalar_t, float>(out, weight, q_scale, out_scale, numel);
+      });
+
+  return out;
+}

--- a/sgl-kernel/csrc/cpu/gemm.cpp
+++ b/sgl-kernel/csrc/cpu/gemm.cpp
@@ -161,6 +161,21 @@ inline void copy_add_stub(
   }
 }
 
+inline void copy_add_stub(
+    float* __restrict__ out, const float* __restrict__ input, const float* __restrict__ bias, int64_t size) {
+  using fVec = at::vec::Vectorized<float>;
+
+  int64_t d;
+#pragma GCC unroll 4
+  for (d = 0; d <= size - fVec::size(); d += fVec::size()) {
+    fVec data = fVec::loadu(input + d) + fVec::loadu(bias + d);
+    data.store(out + d);
+  }
+  for (; d < size; ++d) {
+    out[d] = input[d] + bias[d];
+  }
+}
+
 template <typename scalar_t, bool has_bias>
 inline void scalar_sigmoid_and_mul(
     scalar_t* __restrict__ out,
@@ -581,6 +596,62 @@ void weight_packed_linear_kernel_impl(
   });
 }
 
+// bf16/fp16 input, bf16/fp16 weight (vnni packed) -> fp32 output
+template <typename scalar_t>
+void weight_packed_linear_fp32_out_kernel_impl(
+    float* __restrict__ out,
+    const scalar_t* __restrict__ mat1,
+    const scalar_t* __restrict__ mat2,
+    const float* __restrict__ bias,
+    int64_t M,
+    int64_t N,
+    int64_t K,
+    int64_t mat1_strideM,
+    int64_t out_strideM) {
+  constexpr int64_t BLOCK_M = block_size_m();
+  constexpr int64_t BLOCK_N = block_size_n();
+  const int64_t MB = div_up(M, BLOCK_M);
+  const int64_t NB = div_up(N, BLOCK_N);
+
+  AT_DISPATCH_BOOL(bias != nullptr, has_bias, [&] {
+    parallel_2d(MB, NB, [&](int64_t mb0, int64_t mb1, int64_t nb0, int64_t nb1) {
+      alignas(64) float Ctmp[BLOCK_M * BLOCK_N];
+
+      loop_2d<scalar_t>(mb0, mb1, nb0, nb1, BLOCK_N * K, [&](int64_t mb, int64_t nb, int64_t nb_offset) {
+        int64_t mb_start = mb * BLOCK_M;
+        int64_t mb_size = std::min(M - mb_start, BLOCK_M);
+        int64_t nb_start = nb * BLOCK_N;
+        int64_t nb_size = std::min(N - nb_start, BLOCK_N);
+
+        // bf16 * bf16 -> fp32 accumulation via brgemm
+        at::native::cpublas::brgemm(
+            mb_size, nb_size, K,
+            mat1_strideM, nb_size, BLOCK_N,
+            /* add_C */ false,
+            mat1 + mb_start * mat1_strideM,
+            mat2 + nb_start * K,
+            Ctmp);
+
+        // copy Ctmp (fp32) directly to fp32 output
+        for (int64_t m = 0; m < mb_size; ++m) {
+          if constexpr (has_bias) {
+            copy_add_stub(
+                out + mb_start * out_strideM + nb_start + m * out_strideM,
+                Ctmp + m * BLOCK_N, bias + nb_start, nb_size);
+          } else {
+            std::memcpy(
+                out + mb_start * out_strideM + nb_start + m * out_strideM,
+                Ctmp + m * BLOCK_N,
+                nb_size * sizeof(float));
+          }
+        }
+      });
+
+      at::native::cpublas::brgemm_release();
+    });
+  });
+}
+
 }  // anonymous namespace
 
 // tinygemm interface
@@ -728,7 +799,12 @@ at::Tensor convert_scale_packed(at::Tensor& scale) {
 // out  : [M, N]
 //
 at::Tensor
-weight_packed_linear(at::Tensor& mat1, at::Tensor& mat2, const std::optional<at::Tensor>& bias, bool is_vnni) {
+weight_packed_linear(
+    at::Tensor& mat1,
+    at::Tensor& mat2,
+    const std::optional<at::Tensor>& bias,
+    bool is_vnni,
+    std::optional<at::ScalarType> out_dtype) {
   auto packed_w = is_vnni ? mat2 : convert_weight_packed(mat2);
   bool use_fma_gemm = false;
   if (packed_w.scalar_type() == at::kFloat) {
@@ -748,7 +824,10 @@ weight_packed_linear(at::Tensor& mat1, at::Tensor& mat2, const std::optional<at:
   }
 
   auto dispatch_type = mat1.scalar_type();
-  auto out = at::empty({M, N}, mat1.options());
+  auto out_scalar_type = out_dtype.value_or(dispatch_type);
+  bool fp32_out = (out_scalar_type == at::kFloat) && (dispatch_type != at::kFloat);
+
+  auto out = at::empty({M, N}, mat1.options().dtype(out_scalar_type));
   // strides
   int64_t out_strideM = out.stride(0);
   int64_t mat1_strideM = mat1.stride(0);
@@ -760,22 +839,10 @@ weight_packed_linear(at::Tensor& mat1, at::Tensor& mat2, const std::optional<at:
     bias_data = bias.value().data_ptr<float>();
   }
 
-  AT_DISPATCH_REDUCED_FLOATING_TYPES(dispatch_type, "weight_packed_linear_kernel_impl", [&] {
-    if (use_fma_gemm) {
-      weight_packed_linear_kernel_impl<scalar_t>(
-          out.data_ptr<scalar_t>(),
-          mat1.data_ptr<scalar_t>(),
-          packed_w.data_ptr<float>(),
-          bias_data,
-          nullptr,
-          M,
-          N,
-          K,
-          mat1_strideM,
-          out_strideM);
-    } else {
-      weight_packed_linear_kernel_impl<scalar_t>(
-          out.data_ptr<scalar_t>(),
+  if (fp32_out && !use_fma_gemm) {
+    AT_DISPATCH_REDUCED_FLOATING_TYPES(dispatch_type, "weight_packed_linear_fp32_out", [&] {
+      weight_packed_linear_fp32_out_kernel_impl<scalar_t>(
+          out.data_ptr<float>(),
           mat1.data_ptr<scalar_t>(),
           packed_w.data_ptr<scalar_t>(),
           bias_data,
@@ -784,8 +851,35 @@ weight_packed_linear(at::Tensor& mat1, at::Tensor& mat2, const std::optional<at:
           K,
           mat1_strideM,
           out_strideM);
-    }
-  });
+    });
+  } else {
+    AT_DISPATCH_REDUCED_FLOATING_TYPES(dispatch_type, "weight_packed_linear_kernel_impl", [&] {
+      if (use_fma_gemm) {
+        weight_packed_linear_kernel_impl<scalar_t>(
+            out.data_ptr<scalar_t>(),
+            mat1.data_ptr<scalar_t>(),
+            packed_w.data_ptr<float>(),
+            bias_data,
+            nullptr,
+            M,
+            N,
+            K,
+            mat1_strideM,
+            out_strideM);
+      } else {
+        weight_packed_linear_kernel_impl<scalar_t>(
+            out.data_ptr<scalar_t>(),
+            mat1.data_ptr<scalar_t>(),
+            packed_w.data_ptr<scalar_t>(),
+            bias_data,
+            M,
+            N,
+            K,
+            mat1_strideM,
+            out_strideM);
+      }
+    });
+  }
 
   return out;
 }

--- a/sgl-kernel/csrc/cpu/gemm.h
+++ b/sgl-kernel/csrc/cpu/gemm.h
@@ -67,7 +67,17 @@ inline int64_t get_row_size(int64_t K, bool use_int8_w8a8) {
   return use_int8_w8a8 ? K + sizeof(int32_t) : K;
 }
 
-enum class CPUQuantMethod : int64_t { BF16 = 0, INT8_W8A8 = 1, FP8_W8A16 = 2, INT4_W4A8 = 3 };
+enum class CPUAcTMethod : int { silu_and_mul = 0, swiglu = 1 };
+
+constexpr bool operator==(CPUAcTMethod a, int b) {
+  return static_cast<int>(a) == b;
+}
+
+constexpr bool operator==(int a, CPUAcTMethod b) {
+  return a == static_cast<int>(b);
+}
+
+enum class CPUQuantMethod : int64_t { BF16 = 0, INT8_W8A8 = 1, FP8_W8A16 = 2, INT4_W4A8 = 3, MXFP4 = 4 };
 
 constexpr bool operator==(CPUQuantMethod a, int64_t b) {
   return static_cast<int64_t>(a) == b;
@@ -124,9 +134,9 @@ void fused_experts_int8_kernel_impl(
     int64_t topk,
     int64_t num_tokens_post_pad);
 
-// moe implementations for fp8 w8a16
-template <typename scalar_t>
-void fused_experts_fp8_kernel_impl(
+// moe implementations for fp8 w8a16 and mxfp4
+template <typename scalar_t, typename packed_t, typename param_t, bool is_mxfp4>
+void fused_experts_fp_kernel_impl(
     scalar_t* __restrict__ output,
     scalar_t* __restrict__ ic0,
     scalar_t* __restrict__ ic1,
@@ -135,10 +145,12 @@ void fused_experts_fp8_kernel_impl(
     scalar_t* __restrict__ B_tmp,
     float* __restrict__ C_tmp,
     const scalar_t* __restrict__ input,
-    const at::Float8_e4m3fn* __restrict__ packed_w1,
-    const at::Float8_e4m3fn* __restrict__ packed_w2,
-    const float* __restrict__ w1s,
-    const float* __restrict__ w2s,
+    const packed_t* __restrict__ packed_w1,
+    const packed_t* __restrict__ packed_w2,
+    const float* __restrict__ w1_bias,
+    const float* __restrict__ w2_bias,
+    const param_t* __restrict__ w1s,
+    const param_t* __restrict__ w2s,
     int64_t block_size_N,
     int64_t block_size_K,
     const float* __restrict__ topk_weights,
@@ -150,7 +162,11 @@ void fused_experts_fp8_kernel_impl(
     int64_t K,
     int64_t E,
     int64_t topk,
-    int64_t num_tokens_post_pad);
+    int64_t num_tokens_post_pad,
+    float alpha,
+    float limit,
+    CPUAcTMethod act_func,
+    bool with_bias);
 
 // shared expert implementation for int8 w8a8
 template <typename scalar_t>
@@ -261,6 +277,7 @@ void tinygemm_kernel(
     scalar_t* __restrict__ C,
     scalar_t* __restrict__ Btmp,
     float* __restrict__ Ctmp,
+    const float* __restrict__ Bbias,
     const float* __restrict__ scale,
     int64_t M,
     int64_t N,
@@ -288,6 +305,26 @@ void tinygemm_kernel(
     int64_t ldb,
     int64_t ldc,
     bool brg);
+
+// mxfp4
+template <typename scalar_t>
+void tinygemm_kernel(
+    const scalar_t* __restrict__ A,
+    const uint8_t* __restrict__ B,
+    scalar_t* __restrict__ C,
+    scalar_t* __restrict__ Btmp,
+    float* __restrict__ Ctmp,
+    const float* __restrict__ Bbias,
+    const uint8_t* __restrict__ scale,
+    int64_t M,
+    int64_t N,
+    int64_t K,
+    int64_t lda,
+    int64_t ldb,
+    int64_t ldc,
+    bool brg,
+    int64_t block_size_K,
+    bool do_unpack = true);
 
 template <typename scalar_t>
 void tinygemm_kernel(

--- a/sgl-kernel/csrc/cpu/gemm.h
+++ b/sgl-kernel/csrc/cpu/gemm.h
@@ -73,9 +73,7 @@ enum class CPUAcTMethod : int { silu_and_mul = 0, swiglu = 1, clamped_silu_and_m
 //   limit + alpha ⇒ gpt-oss swiglu.
 //   limit only    ⇒ DSV4-2604B clamped silu_and_mul.
 //   neither       ⇒ plain silu_and_mul.
-inline CPUAcTMethod select_act_func(
-    const std::optional<double>& alpha,
-    const std::optional<double>& limit) {
+inline CPUAcTMethod select_act_func(const std::optional<double>& alpha, const std::optional<double>& limit) {
   if (!limit.has_value()) {
     return CPUAcTMethod::silu_and_mul;
   }
@@ -250,7 +248,10 @@ void shared_expert_fp_kernel_impl(
     float routed_scaling_factor,
     int64_t M,
     int64_t N,
-    int64_t K);
+    int64_t K,
+    float alpha,
+    float limit,
+    CPUAcTMethod act_func);
 
 // tinygemm interface
 template <typename scalar_t>

--- a/sgl-kernel/csrc/cpu/gemm.h
+++ b/sgl-kernel/csrc/cpu/gemm.h
@@ -67,7 +67,20 @@ inline int64_t get_row_size(int64_t K, bool use_int8_w8a8) {
   return use_int8_w8a8 ? K + sizeof(int32_t) : K;
 }
 
-enum class CPUAcTMethod : int { silu_and_mul = 0, swiglu = 1 };
+enum class CPUAcTMethod : int { silu_and_mul = 0, swiglu = 1, clamped_silu_and_mul = 2 };
+
+// Select activation based on which clamp/scale parameters the caller provided:
+//   limit + alpha ⇒ gpt-oss swiglu.
+//   limit only    ⇒ DSV4-2604B clamped silu_and_mul.
+//   neither       ⇒ plain silu_and_mul.
+inline CPUAcTMethod select_act_func(
+    const std::optional<double>& alpha,
+    const std::optional<double>& limit) {
+  if (!limit.has_value()) {
+    return CPUAcTMethod::silu_and_mul;
+  }
+  return alpha.has_value() ? CPUAcTMethod::swiglu : CPUAcTMethod::clamped_silu_and_mul;
+}
 
 constexpr bool operator==(CPUAcTMethod a, int b) {
   return static_cast<int>(a) == b;

--- a/sgl-kernel/csrc/cpu/gemm.h
+++ b/sgl-kernel/csrc/cpu/gemm.h
@@ -218,18 +218,19 @@ void fused_experts_int4_w4a8_kernel_impl(
     int64_t topk,
     int64_t num_tokens_post_pad);
 
-template <typename scalar_t>
-void shared_expert_fp8_kernel_impl(
+// moe implementations for fp8 w8a16 and mxfp4
+template <typename scalar_t, typename packed_t, typename param_t, bool is_mxfp4>
+void shared_expert_fp_kernel_impl(
     scalar_t* __restrict__ output,
     scalar_t* __restrict__ ic0,
     scalar_t* __restrict__ ic1,
     scalar_t* __restrict__ B_tmp,
     float* __restrict__ C_tmp,
     const scalar_t* __restrict__ input,
-    const at::Float8_e4m3fn* __restrict__ packed_w1,
-    const at::Float8_e4m3fn* __restrict__ packed_w2,
-    const float* __restrict__ w1s,
-    const float* __restrict__ w2s,
+    const packed_t* __restrict__ packed_w1,
+    const packed_t* __restrict__ packed_w2,
+    const param_t* __restrict__ w1s,
+    const param_t* __restrict__ w2s,
     int64_t block_size_N,
     int64_t block_size_K,
     const scalar_t* __restrict__ fused_experts_out,

--- a/sgl-kernel/csrc/cpu/gemm_fp8.cpp
+++ b/sgl-kernel/csrc/cpu/gemm_fp8.cpp
@@ -62,6 +62,23 @@ inline void copy_mul_stub(scalar_t* __restrict__ out, const float* __restrict__ 
   }
 }
 
+template <>
+inline void
+copy_add_stub(float* __restrict__ out, const float* __restrict__ input, const float* __restrict__ bias, int64_t size) {
+  using fVec = at::vec::Vectorized<float>;
+  constexpr int kVecSize = fVec::size();
+
+  int64_t d;
+#pragma GCC unroll 4
+  for (d = 0; d <= size - kVecSize; d += kVecSize) {
+    fVec data = fVec::loadu(input + d) + fVec::loadu(bias + d);
+    data.store(out + d);
+  }
+  for (; d < size; ++d) {
+    out[d] = input[d] + bias[d];
+  }
+}
+
 inline void unpack_B(
     at::BFloat16* __restrict__ Btmp,
     const at::Float8_e4m3fn* __restrict__ packed_B,
@@ -913,6 +930,7 @@ void tinygemm_kernel(
     scalar_t* __restrict__ C,
     scalar_t* __restrict__ Btmp,
     float* __restrict__ Ctmp,
+    const float* __restrict__ Bbias,
     const float* __restrict__ scale,
     int64_t M,
     int64_t N,
@@ -923,6 +941,11 @@ void tinygemm_kernel(
     bool brg,
     int64_t block_size_K,
     bool do_unpack) {
+  if (Bbias != nullptr) {
+    tinygemm_kernel<scalar_t, at::Float8_e4m3fn, float, true>(
+        A, B, C, Btmp, Ctmp, scale, Bbias, M, N, K, lda, ldb, ldc, brg, block_size_K, do_unpack);
+    return;
+  }
   tinygemm_kernel<scalar_t, at::Float8_e4m3fn, float, false>(
       A, B, C, Btmp, Ctmp, scale, nullptr, M, N, K, lda, ldb, ldc, brg, block_size_K, do_unpack);
 }
@@ -952,6 +975,7 @@ void tinygemm_kernel(
     scalar_t* __restrict__ C,
     scalar_t* __restrict__ Btmp,
     float* __restrict__ Ctmp,
+    const float* __restrict__ Bbias,
     const uint8_t* __restrict__ scale,
     int64_t M,
     int64_t N,
@@ -962,9 +986,68 @@ void tinygemm_kernel(
     bool brg,
     int64_t block_size_K,
     bool do_unpack) {
+  if (Bbias != nullptr) {
+    tinygemm_kernel<scalar_t, uint8_t, uint8_t, true>(
+        A, B, C, Btmp, Ctmp, scale, Bbias, M, N, K, lda, ldb, ldc, brg, block_size_K, do_unpack);
+    return;
+  }
   tinygemm_kernel<scalar_t, uint8_t, uint8_t, false>(
       A, B, C, Btmp, Ctmp, scale, nullptr, M, N, K, lda, ldb, ldc, brg, block_size_K, do_unpack);
 }
+
+// tinygemm interface
+template <typename scalar_t>
+void tinygemm_kernel(
+    const scalar_t* __restrict__ A,
+    const at::Float8_e4m3fn* __restrict__ B,
+    float* __restrict__ C,
+    scalar_t* __restrict__ Btmp,
+    const float* __restrict__ Bbias,
+    const float* __restrict__ scale,
+    int64_t M,
+    int64_t N,
+    int64_t K,
+    int64_t lda,
+    int64_t ldb,
+    int64_t ldc,
+    bool brg,
+    int64_t block_size_K,
+    bool do_unpack) {
+  if (Bbias != nullptr) {
+    tinygemm_kernel<scalar_t, at::Float8_e4m3fn, float, true>(
+        A, B, C, Btmp, scale, Bbias, M, N, K, lda, ldb, ldc, brg, block_size_K, do_unpack);
+    return;
+  }
+  tinygemm_kernel<scalar_t, at::Float8_e4m3fn, float, false>(
+      A, B, C, Btmp, scale, nullptr, M, N, K, lda, ldb, ldc, brg, block_size_K, do_unpack);
+}
+
+template <typename scalar_t>
+void tinygemm_kernel(
+    const scalar_t* __restrict__ A,
+    const uint8_t* __restrict__ B,
+    float* __restrict__ C,
+    scalar_t* __restrict__ Btmp,
+    const float* __restrict__ Bbias,
+    const uint8_t* __restrict__ scale,
+    int64_t M,
+    int64_t N,
+    int64_t K,
+    int64_t lda,
+    int64_t ldb,
+    int64_t ldc,
+    bool brg,
+    int64_t block_size_K,
+    bool do_unpack) {
+  if (Bbias != nullptr) {
+    tinygemm_kernel<scalar_t, uint8_t, uint8_t, true>(
+        A, B, C, Btmp, scale, Bbias, M, N, K, lda, ldb, ldc, brg, block_size_K, do_unpack);
+    return;
+  }
+  tinygemm_kernel<scalar_t, uint8_t, uint8_t, false>(
+      A, B, C, Btmp, scale, nullptr, M, N, K, lda, ldb, ldc, brg, block_size_K, do_unpack);
+}
+
 
 #define INSTANTIATE_TINYGEMM_TEMPLATE(TYPE_A, TYPE_B, TYPE_S) \
   template void tinygemm_kernel<TYPE_A>(                      \
@@ -973,6 +1056,7 @@ void tinygemm_kernel(
       TYPE_A* __restrict__ C,                                 \
       TYPE_A* __restrict__ Btmp,                              \
       float* __restrict__ Ctmp,                               \
+      const float* __restrict__ Bbias,                        \
       const TYPE_S* __restrict__ scale,                       \
       int64_t M,                                              \
       int64_t N,                                              \

--- a/sgl-kernel/csrc/cpu/hadamard.cpp
+++ b/sgl-kernel/csrc/cpu/hadamard.cpp
@@ -1,0 +1,211 @@
+#include "common.h"
+#include "vec.h"
+
+namespace {
+
+using fVec = at::vec::Vectorized<float>;
+
+// ── Unified scalar FWHT ──
+// For float: buf unused, work=out; casts are no-ops.
+// For bf16/f16: work=buf as scratch; casts do dtype conversion.
+template <typename scalar_t>
+inline void fwht_row_scalar(
+    scalar_t* __restrict__ out,
+    const scalar_t* __restrict__ in,
+    float* __restrict__ buf,
+    int64_t n,
+    float scale) {
+  if (n == 1) {
+    out[0] = static_cast<scalar_t>(static_cast<float>(in[0]) * scale);
+    return;
+  }
+  if (n == 2) {
+    float a = static_cast<float>(in[0]), b = static_cast<float>(in[1]);
+    out[0] = static_cast<scalar_t>((a + b) * scale);
+    out[1] = static_cast<scalar_t>((a - b) * scale);
+    return;
+  }
+  float* work;
+  if constexpr (std::is_same_v<scalar_t, float>) {
+    work = out;
+  } else {
+    work = buf;
+  }
+  // h=1: read from in → work
+  for (int64_t j = 0; j < n; j += 2) {
+    float a = static_cast<float>(in[j]), b = static_cast<float>(in[j + 1]);
+    work[j]     = a + b;
+    work[j + 1] = a - b;
+  }
+  // h=2..n/4: in-place on work
+  const int64_t last_h = n >> 1;
+  for (int64_t h = 2; h < last_h; h <<= 1)
+    for (int64_t j = 0; j < n; j += 2 * h)
+      for (int64_t k = 0; k < h; ++k) {
+        float a = work[j + k], b = work[j + k + h];
+        work[j + k]     = a + b;
+        work[j + k + h] = a - b;
+      }
+  // h=n/2: butterfly + scale → out
+  for (int64_t k = 0; k < last_h; ++k) {
+    float a = work[k], b = work[k + last_h];
+    out[k]          = static_cast<scalar_t>((a + b) * scale);
+    out[k + last_h] = static_cast<scalar_t>((a - b) * scale);
+  }
+}
+
+#if defined(CPU_CAPABILITY_AVX512)
+
+// Phase-1: in-register butterflies h=1,2,4,8.
+// Requires permute/blend intrinsics with no Vectorized equivalent.
+static inline __m512 fwht_phase1_fused(__m512 v) {
+  __m512 p, s, d;
+  p = _mm512_permute_ps(v, 0b10'11'00'01);                          // h=1
+  s = _mm512_add_ps(v, p); d = _mm512_sub_ps(p, v);
+  v = _mm512_mask_blend_ps((__mmask16)0xAAAA, s, d);
+  p = _mm512_permute_ps(v, 0b01'00'11'10);                          // h=2
+  s = _mm512_add_ps(v, p); d = _mm512_sub_ps(p, v);
+  v = _mm512_mask_blend_ps((__mmask16)0xCCCC, s, d);
+  p = _mm512_permutexvar_ps(                                         // h=4
+      _mm512_set_epi32(11,10,9,8, 15,14,13,12, 3,2,1,0, 7,6,5,4), v);
+  s = _mm512_add_ps(v, p); d = _mm512_sub_ps(p, v);
+  v = _mm512_mask_blend_ps((__mmask16)0xF0F0, s, d);
+  p = _mm512_permutexvar_ps(                                         // h=8
+      _mm512_set_epi32(7,6,5,4, 3,2,1,0, 15,14,13,12, 11,10,9,8), v);
+  s = _mm512_add_ps(v, p); d = _mm512_sub_ps(p, v);
+  v = _mm512_mask_blend_ps((__mmask16)0xFF00, s, d);
+  return v;
+}
+
+// fVec wrapper for fwht_phase1_fused
+static inline fVec fwht_phase1(fVec v) {
+  return fVec(fwht_phase1_fused(__m512(v)));
+}
+
+// ── Vectorized dtype conversion (16 elements) ──
+// For float: identity load/store. For bf16/f16: intrinsic conversion.
+template <typename scalar_t> static inline fVec load_cvt(const scalar_t*);
+template <typename scalar_t> static inline void store_cvt(scalar_t*, fVec);
+
+template <> inline fVec load_cvt<float>(const float* p) {
+  return fVec::loadu(p);
+}
+template <> inline fVec load_cvt<at::BFloat16>(const at::BFloat16* p) {
+  return fVec(CVT_BF16_TO_FP32(
+      _mm256_loadu_si256(reinterpret_cast<const __m256i*>(p))));
+}
+template <> inline fVec load_cvt<at::Half>(const at::Half* p) {
+  return fVec(CVT_FP16_TO_FP32(
+      _mm256_loadu_si256(reinterpret_cast<const __m256i*>(p))));
+}
+template <> inline void store_cvt<float>(float* p, fVec v) {
+  v.store(p);
+}
+template <> inline void store_cvt<at::BFloat16>(at::BFloat16* p, fVec v) {
+  _mm256_storeu_si256(reinterpret_cast<__m256i*>(p),
+      (__m256i)_mm512_cvtneps_pbh(__m512(v)));
+}
+template <> inline void store_cvt<at::Half>(at::Half* p, fVec v) {
+  _mm256_storeu_si256(reinterpret_cast<__m256i*>(p),
+      _mm512_cvtps_ph(__m512(v), _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC));
+}
+
+// Phase-2: h=16..last_h-1 vectorized butterflies on float buffer.
+static inline void fwht_phase2(float* __restrict__ buf, int64_t n, int64_t last_h) {
+  for (int64_t h = 16; h < last_h; h <<= 1)
+    for (int64_t j = 0; j < n; j += 2 * h)
+      for (int64_t k = 0; k < h; k += fVec::size()) {
+        fVec a = fVec::loadu(buf + j + k);
+        fVec b = fVec::loadu(buf + j + k + h);
+        (a + b).store(buf + j + k);
+        (a - b).store(buf + j + k + h);
+      }
+}
+
+// Unified AVX-512 FWHT with optional dtype conversion.
+// For float: load_cvt/store_cvt are identity, work=out.
+// For bf16/f16: load_cvt/store_cvt handle conversion, work=buf.
+template <typename scalar_t>
+inline void fwht_row_avx512(
+    scalar_t* __restrict__ out,
+    const scalar_t* __restrict__ in,
+    float* __restrict__ buf,
+    int64_t n,
+    float scale) {
+  fVec sv(scale);
+  if (n == 16) {
+    store_cvt(out, fwht_phase1(load_cvt(in)) * sv);
+    return;
+  }
+
+  float* work;
+  if constexpr (std::is_same_v<scalar_t, float>) {
+    work = out;
+  } else {
+    work = buf;
+  }
+
+  // Phase 1: load (+ convert) → fused butterflies → work
+  for (int64_t j = 0; j < n; j += fVec::size())
+    fwht_phase1(load_cvt(in + j)).store(work + j);
+
+  // Phase 2: h=16..n/4 butterflies on work
+  const int64_t last_h = n >> 1;
+  fwht_phase2(work, n, last_h);
+
+  // Last stage: butterfly + scale (+ convert) → out
+  for (int64_t k = 0; k < last_h; k += fVec::size()) {
+    fVec a = fVec::loadu(work + k);
+    fVec b = fVec::loadu(work + k + last_h);
+    store_cvt(out + k,          (a + b) * sv);
+    store_cvt(out + k + last_h, (a - b) * sv);
+  }
+}
+
+#endif  // CPU_CAPABILITY_AVX512
+
+template <typename scalar_t>
+void fast_hadamard_transform_kernel_impl(
+    scalar_t* __restrict__ output,
+    const scalar_t* __restrict__ input,
+    int64_t rows,
+    int64_t n,
+    float scale) {
+  at::parallel_for(0, rows, 0, [&](int64_t begin, int64_t end) {
+    float* buf = nullptr;
+    std::vector<float> scratch;
+    if constexpr (!std::is_same_v<scalar_t, float>) {
+      scratch.resize(n);
+      buf = scratch.data();
+    }
+    for (int64_t r = begin; r < end; ++r) {
+#if defined(CPU_CAPABILITY_AVX512)
+      if (n >= 16)
+        fwht_row_avx512(output + r * n, input + r * n, buf, n, scale);
+      else
+#endif
+        fwht_row_scalar(output + r * n, input + r * n, buf, n, scale);
+    }
+  });
+}
+
+}  // anonymous namespace
+
+at::Tensor fast_hadamard_transform_cpu(const at::Tensor& x, double scale) {
+  CHECK_INPUT(x);
+  const int64_t n = x.size(-1);
+  TORCH_CHECK(n > 0 && (n & (n - 1)) == 0,
+              "fast_hadamard_transform: last dim must be a power of 2, got ", n);
+
+  const int64_t rows = x.numel() / n;
+  auto out = at::empty_like(x);
+  const float s = static_cast<float>(scale);
+
+  CPU_DISPATCH_FLOATING_TYPES(x.scalar_type(),
+      "fast_hadamard_transform_cpu", [&] {
+    fast_hadamard_transform_kernel_impl<scalar_t>(
+        out.data_ptr<scalar_t>(), x.data_ptr<scalar_t>(), rows, n, s);
+  });
+
+  return out;
+}

--- a/sgl-kernel/csrc/cpu/moe.cpp
+++ b/sgl-kernel/csrc/cpu/moe.cpp
@@ -1315,6 +1315,7 @@ at::Tensor shared_expert_cpu(
     bool inplace,
     bool use_int8_w8a8,
     bool use_fp8_w8a16,
+    bool use_mxfp4,
     const std::optional<at::Tensor>& w1_scale,
     const std::optional<at::Tensor>& w2_scale,
     const std::optional<std::vector<int64_t>> block_size,
@@ -1348,8 +1349,8 @@ at::Tensor shared_expert_cpu(
   int64_t N = w1.size(0) / 2;
 
   // we use int32_t compensation for int8 w8a8
-  int64_t packed_K = get_row_size(K, use_int8_w8a8);
-  int64_t packed_N = get_row_size(N, use_int8_w8a8);
+  int64_t packed_K = use_mxfp4 ? get_row_size<uint8_t>(K) : get_row_size(K, use_int8_w8a8);
+  int64_t packed_N = use_mxfp4 ? get_row_size<uint8_t>(N) : get_row_size(N, use_int8_w8a8);
 
   // check weight shapes
   CHECK_EQ(w2.size(0), K);
@@ -1357,7 +1358,7 @@ at::Tensor shared_expert_cpu(
   CHECK_EQ(packed_w2.size(1), packed_N);
 
   // check scales
-  check_moe_scales(use_int8_w8a8, use_fp8_w8a16, false, w1_scale, w2_scale, block_size);
+  check_moe_scales(use_int8_w8a8, use_fp8_w8a16, use_mxfp4, w1_scale, w2_scale, block_size);
 
   at::Tensor out_hidden_states = inplace ? hidden_states : at::empty_like(hidden_states);
 
@@ -1369,7 +1370,7 @@ at::Tensor shared_expert_cpu(
   //   3. Aq_tmp : [M, K] or [M, N]
   //   4. As_tmp : [M]
   //
-  // for fp8 w8a16:
+  // for fp8 w8a16 and mxfp4:
   //   5. intermediate_cache0 : [M, 2N]
   //   6. B_tmp: [T, MAX_CACHE_BLOCK_SIZE, BLOCK_M, max(K, N)]
   //
@@ -1379,7 +1380,7 @@ at::Tensor shared_expert_cpu(
   if (use_int8_w8a8) {
     buffer_size_nbytes += std::max(M * K, M * N) + M * sizeof(float);
   }
-  if (use_fp8_w8a16) {
+  if (use_fp8_w8a16 || use_mxfp4) {
     buffer_size_nbytes += M * 2 * N * 2 + num_threads * MAX_CACHE_BLOCK_SIZE * BLOCK_M * std::max(K, N) * 2;
   }
 
@@ -1418,7 +1419,7 @@ at::Tensor shared_expert_cpu(
       scalar_t* __restrict__ B_tmp = (scalar_t*)((void*)(intermediate_cache0 + M * 2 * N));
 
       CHECK_MOE_SCALES_FP8(0, 1);
-      shared_expert_fp8_kernel_impl<scalar_t>(
+      shared_expert_fp_kernel_impl<scalar_t, at::Float8_e4m3fn, float, false>(
           out_hidden_states.data_ptr<scalar_t>(),
           intermediate_cache0,
           intermediate_cache1,
@@ -1431,6 +1432,34 @@ at::Tensor shared_expert_cpu(
           w2s.data_ptr<float>(),
           block_size_N,
           block_size_K,
+          conditional_data_ptr<scalar_t>(fused_experts_out),
+          routed_scaling_factor_value,
+          M,
+          N,
+          K);
+    } else if (use_mxfp4) {
+      scalar_t* __restrict__ intermediate_cache0 = (scalar_t*)((void*)(C_tmp + num_threads * 2 * BLOCK_M * BLOCK_N));
+      scalar_t* __restrict__ B_tmp = (scalar_t*)((void*)(intermediate_cache0 + M * 2 * N));
+
+      // mxfp4 supports only group size of 32 (2^5)
+      constexpr int64_t group_size = 32;
+      auto w1s = w1_scale.value();
+      auto w2s = w2_scale.value();
+      TORCH_CHECK(w1s.numel(), 2 * N * K >> 5);
+      TORCH_CHECK(w2s.numel(), K * N >> 5);
+      shared_expert_fp_kernel_impl<scalar_t, uint8_t, uint8_t, true>(
+          out_hidden_states.data_ptr<scalar_t>(),
+          intermediate_cache0,
+          intermediate_cache1,
+          B_tmp,
+          C_tmp,
+          hidden_states.data_ptr<scalar_t>(),
+          packed_w1.data_ptr<uint8_t>(),
+          packed_w2.data_ptr<uint8_t>(),
+          w1s.data_ptr<uint8_t>(),
+          w2s.data_ptr<uint8_t>(),
+          /*block_size_N*/ 1,
+          /*block_size_K*/ group_size,
           conditional_data_ptr<scalar_t>(fused_experts_out),
           routed_scaling_factor_value,
           M,

--- a/sgl-kernel/csrc/cpu/moe.cpp
+++ b/sgl-kernel/csrc/cpu/moe.cpp
@@ -159,6 +159,50 @@ inline void silu_and_mul(
 }
 
 template <typename scalar_t, int BLOCK_N>
+inline void clamped_silu_and_mul(
+    scalar_t* __restrict__ output,
+    const float* __restrict__ input0,  // gate (x)
+    const float* __restrict__ input1,  // up (y)
+    int64_t m_size,
+    int64_t N,
+    const float limit) {
+  using bVec = at::vec::Vectorized<scalar_t>;
+  using fVec = at::vec::Vectorized<float>;
+
+  const fVec one = fVec(1.f);
+  const fVec limit_v = fVec(limit);
+  const fVec nlimit_v = fVec(-limit);
+
+  // no remainder
+  for (int64_t m = 0; m < m_size; ++m) {
+    scalar_t* __restrict__ out = output + m * N;
+    const float* __restrict__ x = input0 + m * BLOCK_N;
+    const float* __restrict__ y = input1 + m * BLOCK_N;
+
+    for (int64_t d = 0; d < BLOCK_N; d += bVec::size()) {
+      fVec x0 = fVec::loadu(x + d);
+      fVec x1 = fVec::loadu(x + d + fVec::size());
+      fVec y0 = fVec::loadu(y + d);
+      fVec y1 = fVec::loadu(y + d + fVec::size());
+      // gate clamped at upper bound; up clamped symmetrically
+      x0 = at::vec::minimum(x0, limit_v);
+      x1 = at::vec::minimum(x1, limit_v);
+      y0 = at::vec::minimum(limit_v, at::vec::maximum(nlimit_v, y0));
+      y1 = at::vec::minimum(limit_v, at::vec::maximum(nlimit_v, y1));
+      // silu(gate) * up
+      x0 = x0 / (one + x0.neg().exp_u20());
+      x1 = x1 / (one + x1.neg().exp_u20());
+      x0 = x0 * y0;
+      x1 = x1 * y1;
+      // convert
+      bVec out_vec = convert_from_float_ext<scalar_t>(x0, x1);
+      out_vec.store(out + d);
+    }
+  }
+}
+
+
+template <typename scalar_t, int BLOCK_N>
 inline void clamp_sigmoid_and_mul(
     scalar_t* __restrict__ output,
     const float* __restrict__ input0,
@@ -640,6 +684,9 @@ void fused_experts_kernel_impl(
       const int64_t offset = offsets[mb];
       if (act_func == CPUAcTMethod::silu_and_mul && use_brgemm) {
         silu_and_mul<scalar_t, BLOCK_N>(ic1 + offset * N + nb * BLOCK_N, C0, C1, m_size, N);
+      } else if (act_func == CPUAcTMethod::clamped_silu_and_mul && use_brgemm) {
+        clamped_silu_and_mul<scalar_t, BLOCK_N>(
+            ic1 + offset * N + nb * BLOCK_N, C0, C1, m_size, N, limit);
       } else if (act_func == CPUAcTMethod::swiglu) {
         clamp_sigmoid_and_mul<scalar_t, BLOCK_N>(ic1 + offset * N, C0, m_size, N, alpha, limit, 0 + nb * BLOCK_N / 2);
         clamp_sigmoid_and_mul<scalar_t, BLOCK_N>(
@@ -1143,7 +1190,7 @@ at::Tensor fused_experts_cpu(
       scalar_t* __restrict__ intermediate_cache0 = (scalar_t*)((void*)(C_tmp + num_threads * 2 * BLOCK_M * BLOCK_N));
       scalar_t* __restrict__ B_tmp = (scalar_t*)((void*)(intermediate_cache0 + M * topk * 2 * N));
       bool with_bias = w1_bias.has_value();
-      auto act_func = alpha.has_value() && limit.has_value() ? CPUAcTMethod::swiglu : CPUAcTMethod::silu_and_mul;
+      auto act_func = select_act_func(alpha, limit);
 
       CHECK_MOE_SCALES_FP8(1, 2);
       fused_experts_fp_kernel_impl<scalar_t, at::Float8_e4m3fn, float, false>(
@@ -1183,7 +1230,7 @@ at::Tensor fused_experts_cpu(
       scalar_t* __restrict__ intermediate_cache0 = (scalar_t*)((void*)(C_tmp + num_threads * 2 * BLOCK_M * BLOCK_N));
       scalar_t* __restrict__ B_tmp = (scalar_t*)((void*)(intermediate_cache0 + M * topk * 2 * N));
       bool with_bias = w1_bias.has_value();
-      auto act_func = alpha.has_value() && limit.has_value() ? CPUAcTMethod::swiglu : CPUAcTMethod::silu_and_mul;
+      auto act_func = select_act_func(alpha, limit);
 
       // mxfp4 supports only group size of 32 (2^5)
       constexpr int64_t group_size = 32;
@@ -1268,7 +1315,7 @@ at::Tensor fused_experts_cpu(
       scalar_t* __restrict__ A_tmp = intermediate_cache2 + M * topk * K;
       float* __restrict__ C_tmp = (float*)((void*)(A_tmp + num_threads * BLOCK_M * K));
       bool with_bias = w1_bias.has_value();
-      auto act_func = alpha.has_value() && limit.has_value() ? CPUAcTMethod::swiglu : CPUAcTMethod::silu_and_mul;
+      auto act_func = select_act_func(alpha, limit);
 
       fused_experts_kernel_impl<scalar_t>(
           out_hidden_states.data_ptr<scalar_t>(),

--- a/sgl-kernel/csrc/cpu/moe.cpp
+++ b/sgl-kernel/csrc/cpu/moe.cpp
@@ -201,7 +201,6 @@ inline void clamped_silu_and_mul(
   }
 }
 
-
 template <typename scalar_t, int BLOCK_N>
 inline void clamp_sigmoid_and_mul(
     scalar_t* __restrict__ output,
@@ -251,7 +250,6 @@ inline void clamp_sigmoid_and_mul(
     }
   }
 }
-
 
 template <typename scalar_t, int BLOCK_M, int BLOCK_N>
 struct tinygemm_kernel_nn2 {
@@ -685,8 +683,7 @@ void fused_experts_kernel_impl(
       if (act_func == CPUAcTMethod::silu_and_mul && use_brgemm) {
         silu_and_mul<scalar_t, BLOCK_N>(ic1 + offset * N + nb * BLOCK_N, C0, C1, m_size, N);
       } else if (act_func == CPUAcTMethod::clamped_silu_and_mul && use_brgemm) {
-        clamped_silu_and_mul<scalar_t, BLOCK_N>(
-            ic1 + offset * N + nb * BLOCK_N, C0, C1, m_size, N, limit);
+        clamped_silu_and_mul<scalar_t, BLOCK_N>(ic1 + offset * N + nb * BLOCK_N, C0, C1, m_size, N, limit);
       } else if (act_func == CPUAcTMethod::swiglu) {
         clamp_sigmoid_and_mul<scalar_t, BLOCK_N>(ic1 + offset * N, C0, m_size, N, alpha, limit, 0 + nb * BLOCK_N / 2);
         clamp_sigmoid_and_mul<scalar_t, BLOCK_N>(
@@ -1007,7 +1004,7 @@ at::Tensor fused_experts_cpu(
     const std::optional<at::Tensor>& w1_zero,
     const std::optional<at::Tensor>& w2_zero,
     const std::optional<std::vector<int64_t>> block_size,
-     const std::optional<at::Tensor>& w1_bias,
+    const std::optional<at::Tensor>& w1_bias,
     const std::optional<at::Tensor>& w2_bias,
     const std::optional<double>& alpha,
     const std::optional<double>& limit,
@@ -1366,6 +1363,8 @@ at::Tensor shared_expert_cpu(
     const std::optional<at::Tensor>& w1_scale,
     const std::optional<at::Tensor>& w2_scale,
     const std::optional<std::vector<int64_t>> block_size,
+    const std::optional<double>& alpha,
+    const std::optional<double>& limit,
     bool is_vnni) {
   auto packed_w1 = is_vnni ? w1 : convert_weight_packed(w1);
   auto packed_w2 = is_vnni ? w2 : convert_weight_packed(w2);
@@ -1464,6 +1463,7 @@ at::Tensor shared_expert_cpu(
     } else if (use_fp8_w8a16) {
       scalar_t* __restrict__ intermediate_cache0 = (scalar_t*)((void*)(C_tmp + num_threads * 2 * BLOCK_M * BLOCK_N));
       scalar_t* __restrict__ B_tmp = (scalar_t*)((void*)(intermediate_cache0 + M * 2 * N));
+      auto act_func = select_act_func(alpha, limit);
 
       CHECK_MOE_SCALES_FP8(0, 1);
       shared_expert_fp_kernel_impl<scalar_t, at::Float8_e4m3fn, float, false>(
@@ -1483,10 +1483,14 @@ at::Tensor shared_expert_cpu(
           routed_scaling_factor_value,
           M,
           N,
-          K);
+          K,
+          alpha.has_value() ? float(alpha.value()) : 0,
+          limit.has_value() ? float(limit.value()) : 0,
+          act_func);
     } else if (use_mxfp4) {
       scalar_t* __restrict__ intermediate_cache0 = (scalar_t*)((void*)(C_tmp + num_threads * 2 * BLOCK_M * BLOCK_N));
       scalar_t* __restrict__ B_tmp = (scalar_t*)((void*)(intermediate_cache0 + M * 2 * N));
+      auto act_func = select_act_func(alpha, limit);
 
       // mxfp4 supports only group size of 32 (2^5)
       constexpr int64_t group_size = 32;
@@ -1511,7 +1515,10 @@ at::Tensor shared_expert_cpu(
           routed_scaling_factor_value,
           M,
           N,
-          K);
+          K,
+          alpha.has_value() ? float(alpha.value()) : 0,
+          limit.has_value() ? float(limit.value()) : 0,
+          act_func);
     } else {
       shared_expert_kernel_impl<scalar_t>(
           out_hidden_states.data_ptr<scalar_t>(),

--- a/sgl-kernel/csrc/cpu/moe.cpp
+++ b/sgl-kernel/csrc/cpu/moe.cpp
@@ -158,6 +158,57 @@ inline void silu_and_mul(
   }
 }
 
+template <typename scalar_t, int BLOCK_N>
+inline void clamp_sigmoid_and_mul(
+    scalar_t* __restrict__ output,
+    const float* __restrict__ input0,
+    int64_t m_size,
+    int64_t N,
+    const float alpha,
+    const float limit,
+    int64_t offset) {
+  using bVec = at::vec::Vectorized<scalar_t>;
+  using fVec = at::vec::Vectorized<float>;
+
+  const fVec one = fVec(1.f);
+  const fVec zero = fVec(0.f);
+  const fVec limit_v = fVec(limit);
+  const fVec nlimit_v = fVec(-limit);
+  const fVec alpha_v = fVec(alpha);
+
+  // no remainder
+  for (int64_t m = 0; m < m_size; ++m) {
+    scalar_t* __restrict__ out = output + m * N;
+    const float* __restrict__ cur_ptr = input0 + m * BLOCK_N;
+    for (int64_t d = 0; d < BLOCK_N; d += bVec::size()) {
+      float tmp_glu0[fVec::size()];     // 16
+      float tmp_linear0[fVec::size()];  // 16
+
+      // interleaved: x[2i] = glu, x[2i+1] = linear
+      for (int j = 0; j < fVec::size(); ++j) {
+        // x0 [0,2,..30]
+        tmp_glu0[j] = cur_ptr[d + j * 2];
+        // y0 [1,3,...31]
+        tmp_linear0[j] = cur_ptr[d + j * 2 + 1];
+      }
+      fVec x0 = fVec::loadu(tmp_glu0);
+      fVec y0 = fVec::loadu(tmp_linear0);
+
+      // clamp
+      x0 = at::vec::minimum(x0, limit_v);
+      y0 = at::vec::minimum(limit_v, at::vec::maximum(nlimit_v, y0));
+      // x * sigmoid(x * alpha)
+      x0 = x0 / (one + (x0 * alpha_v).neg().exp_u20());
+      // (y + 1) * x
+      y0 = y0 + one;
+      x0 = x0 * y0;
+      // // convert
+      convert_from_float_and_store<scalar_t>(out + d / 2 + offset, x0);
+    }
+  }
+}
+
+
 template <typename scalar_t, int BLOCK_M, int BLOCK_N>
 struct tinygemm_kernel_nn2 {
   static inline void apply(
@@ -450,6 +501,8 @@ void fused_experts_kernel_impl(
     const scalar_t* __restrict__ input,
     const scalar_t* __restrict__ packed_w1,
     const scalar_t* __restrict__ packed_w2,
+    const float* __restrict__ w1_bias,
+    const float* __restrict__ w2_bias,
     const float* __restrict__ topk_weights,
     const int32_t* __restrict__ sorted_ids,
     const int32_t* __restrict__ expert_ids,
@@ -459,7 +512,11 @@ void fused_experts_kernel_impl(
     int64_t K,
     int64_t E,
     int64_t topk,
-    int64_t num_tokens_post_pad) {
+    int64_t num_tokens_post_pad,
+    float alpha,
+    float limit,
+    CPUAcTMethod act_func,
+    bool with_bias) {
   // handle 2 tiles per block
   constexpr int64_t BLOCK_M = block_size_m();
   constexpr int64_t BLOCK_N = block_size_n();
@@ -494,6 +551,8 @@ void fused_experts_kernel_impl(
       int32_t expert_id = expert_ids[mb];
       const scalar_t* __restrict__ B0 = packed_w1 + expert_id * stride_e + nb_upper * BLOCK_N * stride_n;
       const scalar_t* __restrict__ B1 = packed_w1 + expert_id * stride_e + nb_lower * BLOCK_N * stride_n;
+      const float* __restrict__ B0_bias = w1_bias + expert_id * 2 * N + nb_upper * BLOCK_N;
+      const float* __restrict__ B1_bias = w1_bias + expert_id * 2 * N + nb_lower * BLOCK_N;
 
       int64_t m_size = offsets[mb + 1] - offsets[mb];
 
@@ -533,23 +592,58 @@ void fused_experts_kernel_impl(
             /* B     */ B1,
             /* C     */ C1);
 
-        // 1.d silu and mul
-        const int64_t offset = offsets[mb];
-        silu_and_mul<scalar_t, BLOCK_N>(ic1 + offset * N + nb * BLOCK_N, C0, C1, m_size, N);
       } else {
-        // fused 1.bcd: silu_and_mul(A @ B0, A @ B1)
         const int64_t offset = offsets[mb];
-        tinygemm_kernel(
-            /* A     */ A,
-            /* B0    */ B0,
-            /* B1    */ B1,
-            /* C     */ ic1 + offset * N + nb * BLOCK_N,
-            /* M     */ m_size,
-            /* N     */ n_size,
-            /* K     */ K,
-            /* lda   */ K,
-            /* ldb   */ n_size,
-            /* ldc   */ N);
+        if (act_func == CPUAcTMethod::swiglu) {
+          tinygemm_kernel(
+              /* A     */ A,
+              /* B     */ B0,
+              /* C     */ C0,
+              /* M     */ m_size,
+              /* N     */ n_size,
+              /* K     */ K,
+              /* lda   */ K,
+              /* ldb   */ n_size,
+              /* ldc   */ BLOCK_N);
+          tinygemm_kernel(
+              /* A     */ A,
+              /* B     */ B1,
+              /* C     */ C1,
+              /* M     */ m_size,
+              /* N     */ n_size,
+              /* K     */ K,
+              /* lda   */ K,
+              /* ldb   */ n_size,
+              /* ldc   */ BLOCK_N);
+        } else {
+          // fused 1.bcd: silu_and_mul(A @ B0, A @ B1)
+          tinygemm_kernel(
+              /* A     */ A,
+              /* B0    */ B0,
+              /* B1    */ B1,
+              /* C     */ ic1 + offset * N + nb * BLOCK_N,
+              /* M     */ m_size,
+              /* N     */ n_size,
+              /* K     */ K,
+              /* lda   */ K,
+              /* ldb   */ n_size,
+              /* ldc   */ N);
+        }
+      }
+      if (with_bias) {
+        for (int64_t m = 0; m < m_size; ++m) {
+          add_bias_stub(C0 + m * BLOCK_N, B0_bias, n_size);
+          add_bias_stub(C1 + m * BLOCK_N, B1_bias, n_size);
+        }
+      }
+      // 1.d silu and mul
+      const int64_t offset = offsets[mb];
+      if (act_func == CPUAcTMethod::silu_and_mul && use_brgemm) {
+        silu_and_mul<scalar_t, BLOCK_N>(ic1 + offset * N + nb * BLOCK_N, C0, C1, m_size, N);
+      } else if (act_func == CPUAcTMethod::swiglu) {
+        clamp_sigmoid_and_mul<scalar_t, BLOCK_N>(ic1 + offset * N, C0, m_size, N, alpha, limit, 0 + nb * BLOCK_N / 2);
+        clamp_sigmoid_and_mul<scalar_t, BLOCK_N>(
+            ic1 + offset * N, C1, m_size, N, alpha, limit, N / 2 + nb * BLOCK_N / 2);
       }
     });
 
@@ -586,6 +680,7 @@ void fused_experts_kernel_impl(
       // B shape [IC, n_size] in vnni format
       int32_t expert_id = expert_ids[mb];
       const scalar_t* __restrict__ B = packed_w2 + expert_id * stride_e2 + nb * BLOCK_N * stride_oc;
+      const float* __restrict__ B_bias = w2_bias + expert_id * OC + nb * BLOCK_N;
 
       // 2.a gemm: C = A @ B
       if (use_brgemm) {
@@ -611,6 +706,11 @@ void fused_experts_kernel_impl(
             /* lda   */ IC,
             /* ldb   */ n_size,
             /* ldc   */ BLOCK_N);
+      }
+      if (with_bias) {
+        for (int64_t m = 0; m < m_size; ++m) {
+          add_bias_stub(C + m * BLOCK_N, B_bias, n_size);
+        }
       }
 
       // 2.b copy from C to ic2 in original order
@@ -807,6 +907,7 @@ void shared_expert_kernel_impl(
 static inline void check_moe_scales(
     bool use_int8_w8a8,
     bool use_fp8_w8a16,
+    bool use_mxfp4,
     const std::optional<at::Tensor>& w1_scale,
     const std::optional<at::Tensor>& w2_scale,
     const std::optional<std::vector<int64_t>> block_size) {
@@ -819,6 +920,12 @@ static inline void check_moe_scales(
     TORCH_CHECK(w2_scale.has_value(), "missing w2_scale for fp8 w8a16.");
     TORCH_CHECK(block_size.has_value(), "missing block_size for fp8 w8a16.");
     TORCH_CHECK(block_size.value().size() == 2, "expect block_size.size() to be 2.");
+  }
+  if (use_mxfp4) {
+    TORCH_CHECK(w1_scale.has_value(), "missing w1_scale for mxfp4.");
+    TORCH_CHECK(w2_scale.has_value(), "missing w2_scale for mxfp4.");
+    TORCH_CHECK(w1_scale.value().scalar_type() == at::kByte, "expect w1_scale to be uint8.");
+    TORCH_CHECK(w2_scale.value().scalar_type() == at::kByte, "expect w2_scale to be uint8.");
   }
 }
 
@@ -834,8 +941,8 @@ static inline void check_moe_scales(
   TORCH_CHECK(w2s.size(DIM1) == div_up(N, block_size_K))
 
 // hidden_states: [M, K]
-// w1: [E, 2N, K]
-// w2: [E, K, N]
+// w1: [E, 2N, K] or [E, 2N, K / 2] for uint8
+// w2: [E, K, N] or [E, K, N / 2] for uint8
 // topk_weights: [M, topk]
 // topk_ids: [M, topk] (int32_t)
 //
@@ -853,6 +960,10 @@ at::Tensor fused_experts_cpu(
     const std::optional<at::Tensor>& w1_zero,
     const std::optional<at::Tensor>& w2_zero,
     const std::optional<std::vector<int64_t>> block_size,
+     const std::optional<at::Tensor>& w1_bias,
+    const std::optional<at::Tensor>& w2_bias,
+    const std::optional<double>& alpha,
+    const std::optional<double>& limit,
     bool is_vnni) {
   auto packed_w1 = is_vnni ? w1 : convert_weight_packed(w1);
   auto packed_w2 = is_vnni ? w2 : convert_weight_packed(w2);
@@ -892,8 +1003,12 @@ at::Tensor fused_experts_cpu(
   int64_t topk = topk_weights_.size(1);
 
   // we use int32_t compensation for int8 w8a8
-  int64_t packed_K = get_row_size(K, moe_comp_method == CPUQuantMethod::INT8_W8A8);
-  int64_t packed_N = get_row_size(N, moe_comp_method == CPUQuantMethod::INT8_W8A8);
+  int64_t packed_K = moe_comp_method == CPUQuantMethod::MXFP4
+                         ? get_row_size<uint8_t>(K)
+                         : get_row_size(K, moe_comp_method == CPUQuantMethod::INT8_W8A8);
+  int64_t packed_N = moe_comp_method == CPUQuantMethod::MXFP4
+                         ? get_row_size<uint8_t>(N)
+                         : get_row_size(N, moe_comp_method == CPUQuantMethod::INT8_W8A8);
 
   // check weight shapes
   CHECK_EQ(w2.size(0), E);
@@ -906,6 +1021,7 @@ at::Tensor fused_experts_cpu(
   check_moe_scales(
       moe_comp_method == CPUQuantMethod::INT8_W8A8,
       moe_comp_method == CPUQuantMethod::FP8_W8A16,
+      moe_comp_method == CPUQuantMethod::MXFP4,
       w1_scale,
       w2_scale,
       block_size);
@@ -960,7 +1076,7 @@ at::Tensor fused_experts_cpu(
   //   5. Aq_tmp : [M, K] or [M * topk, N]
   //   6. As_tmp : [M * topk]
   //
-  // for fp8 w8a16:
+  // for fp8 w8a16 and mxfp4:
   //   7. intermediate_cache0 : [M * topk, 2N]
   //   8. B_tmp : [T, MAX_CACHE_BLOCK_SIZE, BLOCK_N, std::max(K, N)]
   //
@@ -973,7 +1089,7 @@ at::Tensor fused_experts_cpu(
   if (moe_comp_method == CPUQuantMethod::INT8_W8A8) {
     buffer_size_nbytes += std::max(M * K, M * topk * N) + M * topk * sizeof(float);
   }
-  if (moe_comp_method == CPUQuantMethod::FP8_W8A16) {
+  if (moe_comp_method == CPUQuantMethod::FP8_W8A16 || moe_comp_method == CPUQuantMethod::MXFP4) {
     buffer_size_nbytes += M * topk * 2 * N * 2 + num_threads * MAX_CACHE_BLOCK_SIZE * BLOCK_N * std::max(K, N) * 2;
   }
   if (moe_comp_method == CPUQuantMethod::INT4_W4A8) {
@@ -1026,9 +1142,11 @@ at::Tensor fused_experts_cpu(
       float* __restrict__ C_tmp = (float*)((void*)(A_tmp + num_threads * BLOCK_M * K));
       scalar_t* __restrict__ intermediate_cache0 = (scalar_t*)((void*)(C_tmp + num_threads * 2 * BLOCK_M * BLOCK_N));
       scalar_t* __restrict__ B_tmp = (scalar_t*)((void*)(intermediate_cache0 + M * topk * 2 * N));
+      bool with_bias = w1_bias.has_value();
+      auto act_func = alpha.has_value() && limit.has_value() ? CPUAcTMethod::swiglu : CPUAcTMethod::silu_and_mul;
 
       CHECK_MOE_SCALES_FP8(1, 2);
-      fused_experts_fp8_kernel_impl(
+      fused_experts_fp_kernel_impl<scalar_t, at::Float8_e4m3fn, float, false>(
           out_hidden_states.data_ptr<scalar_t>(),
           intermediate_cache0,
           intermediate_cache1,
@@ -1039,6 +1157,8 @@ at::Tensor fused_experts_cpu(
           hidden_states.data_ptr<scalar_t>(),
           packed_w1.data_ptr<at::Float8_e4m3fn>(),
           packed_w2.data_ptr<at::Float8_e4m3fn>(),
+          with_bias ? w1_bias.value().data_ptr<float>() : nullptr,
+          with_bias ? w2_bias.value().data_ptr<float>() : nullptr,
           w1s.data_ptr<float>(),
           w2s.data_ptr<float>(),
           block_size_N,
@@ -1052,7 +1172,56 @@ at::Tensor fused_experts_cpu(
           K,
           E,
           topk,
-          num_tokens_post_pad);
+          num_tokens_post_pad,
+          alpha.has_value() ? float(alpha.value()) : 0,
+          limit.has_value() ? float(limit.value()) : 0,
+          act_func,
+          with_bias);
+    } else if (moe_comp_method == CPUQuantMethod::MXFP4) {
+      scalar_t* __restrict__ A_tmp = (scalar_t*)((void*)(intermediate_cache2 + M * topk * K));
+      float* __restrict__ C_tmp = (float*)((void*)(A_tmp + num_threads * BLOCK_M * K));
+      scalar_t* __restrict__ intermediate_cache0 = (scalar_t*)((void*)(C_tmp + num_threads * 2 * BLOCK_M * BLOCK_N));
+      scalar_t* __restrict__ B_tmp = (scalar_t*)((void*)(intermediate_cache0 + M * topk * 2 * N));
+      bool with_bias = w1_bias.has_value();
+      auto act_func = alpha.has_value() && limit.has_value() ? CPUAcTMethod::swiglu : CPUAcTMethod::silu_and_mul;
+
+      // mxfp4 supports only group size of 32 (2^5)
+      constexpr int64_t group_size = 32;
+      auto w1s = w1_scale.value();
+      auto w2s = w2_scale.value();
+      TORCH_CHECK(w1s.numel(), E * 2 * N * K >> 5);
+      TORCH_CHECK(w2s.numel(), E * K * N >> 5);
+      fused_experts_fp_kernel_impl<scalar_t, uint8_t, uint8_t, true>(
+          out_hidden_states.data_ptr<scalar_t>(),
+          intermediate_cache0,
+          intermediate_cache1,
+          intermediate_cache2,
+          A_tmp,
+          B_tmp,
+          C_tmp,
+          hidden_states.data_ptr<scalar_t>(),
+          packed_w1.data_ptr<uint8_t>(),
+          packed_w2.data_ptr<uint8_t>(),
+          with_bias ? w1_bias.value().data_ptr<float>() : nullptr,
+          with_bias ? w2_bias.value().data_ptr<float>() : nullptr,
+          w1s.data_ptr<uint8_t>(),
+          w2s.data_ptr<uint8_t>(),
+          /*block_size_N*/ 1,
+          /*block_size_K*/ group_size,
+          topk_weights_.data_ptr<float>(),
+          sorted_ids,
+          expert_ids,
+          offsets,
+          M,
+          N,
+          K,
+          E,
+          topk,
+          num_tokens_post_pad,
+          alpha.has_value() ? float(alpha.value()) : 0,
+          limit.has_value() ? float(limit.value()) : 0,
+          act_func,
+          with_bias);
     } else if (moe_comp_method == CPUQuantMethod::INT4_W4A8) {
       uint8_t* __restrict__ A_tmp = (uint8_t*)((void*)(intermediate_cache2 + M * topk * K));
       float* __restrict__ C_tmp = (float*)((void*)(A_tmp + num_threads * BLOCK_M * K));
@@ -1098,6 +1267,8 @@ at::Tensor fused_experts_cpu(
     } else {
       scalar_t* __restrict__ A_tmp = intermediate_cache2 + M * topk * K;
       float* __restrict__ C_tmp = (float*)((void*)(A_tmp + num_threads * BLOCK_M * K));
+      bool with_bias = w1_bias.has_value();
+      auto act_func = alpha.has_value() && limit.has_value() ? CPUAcTMethod::swiglu : CPUAcTMethod::silu_and_mul;
 
       fused_experts_kernel_impl<scalar_t>(
           out_hidden_states.data_ptr<scalar_t>(),
@@ -1108,6 +1279,8 @@ at::Tensor fused_experts_cpu(
           hidden_states.data_ptr<scalar_t>(),
           packed_w1.data_ptr<scalar_t>(),
           packed_w2.data_ptr<scalar_t>(),
+          with_bias ? w1_bias.value().data_ptr<float>() : nullptr,
+          with_bias ? w2_bias.value().data_ptr<float>() : nullptr,
           topk_weights_.data_ptr<float>(),
           sorted_ids,
           expert_ids,
@@ -1117,7 +1290,11 @@ at::Tensor fused_experts_cpu(
           K,
           E,
           topk,
-          num_tokens_post_pad);
+          num_tokens_post_pad,
+          alpha.has_value() ? float(alpha.value()) : 0,
+          limit.has_value() ? float(limit.value()) : 0,
+          act_func,
+          with_bias);
     }
   });
   return out_hidden_states;
@@ -1180,7 +1357,7 @@ at::Tensor shared_expert_cpu(
   CHECK_EQ(packed_w2.size(1), packed_N);
 
   // check scales
-  check_moe_scales(use_int8_w8a8, use_fp8_w8a16, w1_scale, w2_scale, block_size);
+  check_moe_scales(use_int8_w8a8, use_fp8_w8a16, false, w1_scale, w2_scale, block_size);
 
   at::Tensor out_hidden_states = inplace ? hidden_states : at::empty_like(hidden_states);
 

--- a/sgl-kernel/csrc/cpu/moe.h
+++ b/sgl-kernel/csrc/cpu/moe.h
@@ -171,3 +171,110 @@ inline void silu_and_mul_stub(
     out_vec.store(out + d);
   }
 }
+
+
+template <typename scalar_t>
+inline void copy_mul_stub(scalar_t* __restrict__ out, const float* __restrict__ input, float weight, int64_t size) {
+  using bVec = at::vec::Vectorized<scalar_t>;
+  using fVec = at::vec::Vectorized<float>;
+  constexpr int kVecSize = bVec::size();
+  const fVec weight_vec = fVec(weight);
+  int64_t d;
+#pragma GCC unroll 4
+  for (d = 0; d <= size - kVecSize; d += kVecSize) {
+    fVec data0 = fVec::loadu(input + d) * weight_vec;
+    fVec data1 = fVec::loadu(input + d + fVec::size()) * weight_vec;
+    bVec out_vec = convert_from_float_ext<scalar_t>(data0, data1);
+    out_vec.store(out + d);
+  }
+  for (; d < size; ++d) {
+    out[d] = static_cast<scalar_t>(input[d] * weight);
+  }
+}
+
+// input = input + input2
+inline void add_bias_stub(float* __restrict__ input, const float* __restrict__ input2, int64_t size) {
+  using fVec = at::vec::Vectorized<float>;
+  constexpr int kVecSize = fVec::size();
+  int64_t d;
+#pragma GCC unroll 4
+  for (d = 0; d <= size - kVecSize; d += kVecSize) {
+    fVec x_fvec = fVec::loadu(input + d);
+    fVec y_fvec = fVec::loadu(input2 + d);
+    x_fvec = x_fvec + y_fvec;
+    x_fvec.store(input + d);
+  }
+  for (; d < size; ++d) {
+    input[d] = input[d] + input2[d];
+  }
+}
+
+template <typename scalar_t>
+inline void copy_mul_stub(scalar_t* __restrict__ out, const scalar_t* __restrict__ input, float weight, int64_t size) {
+  using bVec = at::vec::Vectorized<scalar_t>;
+  using fVec = at::vec::Vectorized<float>;
+  constexpr int kVecSize = bVec::size();
+  const fVec weight_vec = fVec(weight);
+  int64_t d;
+#pragma GCC unroll 4
+  for (d = 0; d <= size - kVecSize; d += kVecSize) {
+    bVec x = bVec::loadu(input + d);
+    fVec x0, x1;
+    std::tie(x0, x1) = at::vec::convert_to_float(x);
+    x0 = x0 * weight_vec;
+    x1 = x1 * weight_vec;
+    bVec out_vec = convert_from_float_ext<scalar_t>(x0, x1);
+    out_vec.store(out + d);
+  }
+  for (; d < size; ++d) {
+    out[d] = static_cast<scalar_t>(input[d] * weight);
+  }
+}
+
+template <typename scalar_t>
+inline void clamp_sigmoid_and_mul_stub(
+    scalar_t* __restrict__ out,
+    const scalar_t* __restrict__ input,
+    int64_t size,
+    const float alpha,
+    const float limit) {
+  using bVec = at::vec::Vectorized<scalar_t>;
+  using fVec = at::vec::Vectorized<float>;
+  const fVec one = fVec(1.f);
+  const fVec zero = fVec(0.f);
+  const fVec limit_v = fVec(limit);
+  const fVec nlimit_v = fVec(-limit);
+  const fVec alpha_v = fVec(alpha);
+
+  // no remainder
+#pragma GCC unroll 4
+  for (int64_t d = 0; d < size; d += bVec::size()) {
+    bVec x = bVec::loadu(input + d);
+    fVec x0_, y0_;
+    std::tie(x0_, y0_) = at::vec::convert_to_float(x);
+    float tmp_buffer[fVec::size() * 2];  // 32
+    float tmp_glu[fVec::size()];         // 16
+    float tmp_linear[fVec::size()];      // 16
+    x0_.store(tmp_buffer);
+    y0_.store(tmp_buffer + fVec::size());
+    // interleaved: x[2i] = glu, x[2i+1] = linear
+    for (int j = 0; j < fVec::size(); ++j) {
+      // x0 [0,2,..30]
+      tmp_glu[j] = tmp_buffer[j * 2];
+      // y0 [1,3,...31]
+      tmp_linear[j] = tmp_buffer[j * 2 + 1];
+    }
+    fVec x0 = fVec::loadu(tmp_glu);
+    fVec y0 = fVec::loadu(tmp_linear);
+
+    // clamp
+    x0 = at::vec::minimum(x0, limit_v);
+    y0 = at::vec::minimum(limit_v, at::vec::maximum(nlimit_v, y0));
+    // x * sigmoid(x * alpha)
+    x0 = x0 / (one + (x0 * alpha_v).neg().exp_u20());
+    // (y + 1) * x
+    y0 = y0 + one;
+    x0 = x0 * y0;
+    convert_from_float_and_store<scalar_t>(out + d / 2, x0);
+  }
+}

--- a/sgl-kernel/csrc/cpu/moe.h
+++ b/sgl-kernel/csrc/cpu/moe.h
@@ -174,6 +174,44 @@ inline void silu_and_mul_stub(
 
 
 template <typename scalar_t>
+inline void clamped_silu_and_mul_stub(
+    scalar_t* __restrict__ out,
+    const scalar_t* __restrict__ input,   // gate buffer
+    const scalar_t* __restrict__ input2,  // up buffer
+    int64_t size,
+    const float limit) {
+  using bVec = at::vec::Vectorized<scalar_t>;
+  using fVec = at::vec::Vectorized<float>;
+  const fVec one = fVec(1.f);
+  const fVec limit_v = fVec(limit);
+  const fVec nlimit_v = fVec(-limit);
+
+  // no remainder
+#pragma GCC unroll 4
+  for (int64_t d = 0; d < size; d += bVec::size()) {
+    bVec x = bVec::loadu(input + d);
+    fVec x0, x1;
+    std::tie(x0, x1) = at::vec::convert_to_float(x);
+    bVec y = bVec::loadu(input2 + d);
+    fVec y0, y1;
+    std::tie(y0, y1) = at::vec::convert_to_float(y);
+    // gate: clamp at upper bound only; up: clamp symmetrically
+    x0 = at::vec::minimum(x0, limit_v);
+    x1 = at::vec::minimum(x1, limit_v);
+    y0 = at::vec::minimum(limit_v, at::vec::maximum(nlimit_v, y0));
+    y1 = at::vec::minimum(limit_v, at::vec::maximum(nlimit_v, y1));
+    // silu(gate) * up
+    x0 = x0 / (one + x0.neg().exp_u20());
+    x1 = x1 / (one + x1.neg().exp_u20());
+    x0 = x0 * y0;
+    x1 = x1 * y1;
+    bVec out_vec = convert_from_float_ext<scalar_t>(x0, x1);
+    out_vec.store(out + d);
+  }
+}
+
+
+template <typename scalar_t>
 inline void copy_mul_stub(scalar_t* __restrict__ out, const float* __restrict__ input, float weight, int64_t size) {
   using bVec = at::vec::Vectorized<scalar_t>;
   using fVec = at::vec::Vectorized<float>;

--- a/sgl-kernel/csrc/cpu/moe_fp8.cpp
+++ b/sgl-kernel/csrc/cpu/moe_fp8.cpp
@@ -2,8 +2,8 @@
 #include "gemm.h"
 #include "moe.h"
 
-template <typename scalar_t>
-void fused_experts_fp8_kernel_impl(
+template <typename scalar_t, typename packed_t, typename param_t, bool is_mxfp4>
+void fused_experts_fp_kernel_impl(
     scalar_t* __restrict__ output,
     scalar_t* __restrict__ ic0,
     scalar_t* __restrict__ ic1,
@@ -12,10 +12,12 @@ void fused_experts_fp8_kernel_impl(
     scalar_t* __restrict__ B_tmp,
     float* __restrict__ C_tmp,
     const scalar_t* __restrict__ input,
-    const at::Float8_e4m3fn* __restrict__ packed_w1,
-    const at::Float8_e4m3fn* __restrict__ packed_w2,
-    const float* __restrict__ w1s,
-    const float* __restrict__ w2s,
+    const packed_t* __restrict__ packed_w1,
+    const packed_t* __restrict__ packed_w2,
+    const float* __restrict__ w1_bias,
+    const float* __restrict__ w2_bias,
+    const param_t* __restrict__ w1s,
+    const param_t* __restrict__ w2s,
     int64_t block_size_N,
     int64_t block_size_K,
     const float* __restrict__ topk_weights,
@@ -27,7 +29,11 @@ void fused_experts_fp8_kernel_impl(
     int64_t K,
     int64_t E,
     int64_t topk,
-    int64_t num_tokens_post_pad) {
+    int64_t num_tokens_post_pad,
+    float alpha,
+    float limit,
+    CPUAcTMethod act_func,
+    bool with_bias) {
   constexpr int64_t BLOCK_M = block_size_m();
   constexpr int64_t BLOCK_N = block_size_n();
 
@@ -38,11 +44,20 @@ void fused_experts_fp8_kernel_impl(
   int64_t scale_size_K = div_up(K, block_size_K);
   int64_t blocks_n_per_group = block_size_N / BLOCK_N;
 
-  const int64_t stride_e = 2 * N * K;
-  const int64_t stride_n = K;
+  std::function<int64_t(int64_t)> scale_offset_per_block;
+  if constexpr (is_mxfp4) {
+    scale_offset_per_block = [&](int64_t a) { return a * BLOCK_N; };
+  } else {
+    scale_offset_per_block = [&](int64_t a) { return a / blocks_n_per_group; };
+  }
+
+  const int64_t packed_K = get_row_size<packed_t>(K);
+
+  const int64_t stride_e = 2 * N * packed_K;
+  const int64_t stride_n = packed_K;
 
   int64_t avg_M = std::max(int64_t(1), M * topk / E);
-  const bool use_brgemm = can_use_brgemm<at::Float8_e4m3fn>(avg_M);
+  const bool use_brgemm = can_use_brgemm<packed_t>(avg_M);
 
   int64_t B_tmp_size_per_thread = MAX_CACHE_BLOCK_SIZE * BLOCK_N * std::max(K, N);
 
@@ -52,14 +67,15 @@ void fused_experts_fp8_kernel_impl(
     int tid = get_thread_num();
     scalar_t* __restrict__ A = A_tmp + tid * BLOCK_M * K;
 
-    loop_2d<at::Float8_e4m3fn>(mb0, mb1, nb0, nb1, BLOCK_N * K, [&](int64_t mb, int64_t nb, int64_t nb_offset) {
+    loop_2d<packed_t>(mb0, mb1, nb0, nb1, BLOCK_N * K, [&](int64_t mb, int64_t nb, int64_t nb_offset) {
       int64_t n_size = std::min(2 * N - nb * BLOCK_N, BLOCK_N);
 
       // B shape [K, n_size] in vnni format
       int32_t expert_id = expert_ids[mb];
-      const at::Float8_e4m3fn* __restrict__ B = packed_w1 + expert_id * stride_e + nb * BLOCK_N * stride_n;
-      const float* __restrict__ Bs =
-          w1s + expert_id * scale_size_N * scale_size_K + (nb / blocks_n_per_group) * scale_size_K;
+      const packed_t* __restrict__ B = packed_w1 + expert_id * stride_e + nb * BLOCK_N * stride_n;
+      const param_t* __restrict__ Bs =
+          w1s + expert_id * scale_size_N * scale_size_K + scale_offset_per_block(nb) * scale_size_K;
+      const float* __restrict__ B_bias = with_bias ? w1_bias + expert_id * 2 * N + nb * BLOCK_N : nullptr;
 
       // do unpacking for the first row or a new expert
       int32_t pre_expert_id = mb == 0 ? -1 : expert_ids[mb - 1];
@@ -83,6 +99,7 @@ void fused_experts_fp8_kernel_impl(
           /*   C            */ ic0 + offset * 2 * N + nb * BLOCK_N,
           /*   Btmp         */ B_tmp + tid * B_tmp_size_per_thread + nb_offset * BLOCK_N * K,
           /*   Ctmp         */ C_tmp + tid * 2 * BLOCK_M * BLOCK_N,
+          /*   Bbias        */ B_bias,
           /*   scale        */ Bs,
           /*   M            */ m_size,
           /*   N            */ n_size,
@@ -101,11 +118,20 @@ void fused_experts_fp8_kernel_impl(
   });
 
   // stage 1.5: intermediate_cache1 = silu(intermediate_cache0)
-  at::parallel_for(0, M * topk, 0, [&](int64_t begin, int64_t end) {
-    for (int64_t m = begin; m < end; ++m) {
-      silu_and_mul_stub(ic1 + m * N, ic0 + m * 2 * N, ic0 + m * 2 * N + N, N);
-    }
-  });
+  if (act_func == CPUAcTMethod::silu_and_mul) {
+    at::parallel_for(0, M * topk, 0, [&](int64_t begin, int64_t end) {
+      for (int64_t m = begin; m < end; ++m) {
+        silu_and_mul_stub(ic1 + m * N, ic0 + m * 2 * N, ic0 + m * 2 * N + N, N);
+      }
+    });
+  } else if (act_func == CPUAcTMethod::swiglu) {
+    at::parallel_for(0, M * topk, 0, [&](int64_t begin, int64_t end) {
+      for (int64_t m = begin; m < end; ++m) {
+        clamp_sigmoid_and_mul_stub(ic1 + m * N, ic0 + m * 2 * N, N, alpha, limit);
+        clamp_sigmoid_and_mul_stub(ic1 + m * N + N / 2, ic0 + m * 2 * N + N, N, alpha, limit);
+      }
+    });
+  }
 
   // stage 2: intermediate_cache2 = intermediate_cache1 @ w2
   //   w2 : [E, K, N] as [E, OC, IC]
@@ -115,15 +141,16 @@ void fused_experts_fp8_kernel_impl(
   const int64_t NB2 = div_up(OC, BLOCK_N);
   scale_size_N = div_up(K, block_size_N);
   scale_size_K = div_up(N, block_size_K);
-  const int64_t stride_e2 = OC * IC;
-  const int64_t stride_oc = IC;
+  const int64_t packed_IC = get_row_size<packed_t>(IC);
+  const int64_t stride_e2 = OC * packed_IC;
+  const int64_t stride_oc = packed_IC;
 
   // parallel on [MB2, NB2]
   parallel_2d(MB2, NB2, [&](int64_t mb0, int64_t mb1, int64_t nb0, int64_t nb1) {
     int tid = get_thread_num();
     alignas(64) scalar_t C[BLOCK_M * BLOCK_K];
 
-    loop_2d<at::Float8_e4m3fn>(mb0, mb1, nb0, nb1, BLOCK_N * IC, [&](int64_t mb, int64_t nb, int64_t nb_offset) {
+    loop_2d<packed_t>(mb0, mb1, nb0, nb1, BLOCK_N * IC, [&](int64_t mb, int64_t nb, int64_t nb_offset) {
       int64_t m_size = offsets[mb + 1] - offsets[mb];
       int64_t n_size = std::min(OC - nb * BLOCK_N, BLOCK_N);
 
@@ -134,9 +161,10 @@ void fused_experts_fp8_kernel_impl(
 
       // B shape [IC, n_size] in vnni format
       int32_t expert_id = expert_ids[mb];
-      const at::Float8_e4m3fn* __restrict__ B = packed_w2 + expert_id * stride_e2 + nb * BLOCK_N * stride_oc;
-      const float* __restrict__ Bs =
-          w2s + expert_id * scale_size_N * scale_size_K + (nb / blocks_n_per_group) * scale_size_K;
+      const packed_t* __restrict__ B = packed_w2 + expert_id * stride_e2 + nb * BLOCK_N * stride_oc;
+      const param_t* __restrict__ Bs =
+          w2s + expert_id * scale_size_N * scale_size_K + scale_offset_per_block(nb) * scale_size_K;
+      const float* __restrict__ B_bias = with_bias ? w2_bias + expert_id * OC + nb * BLOCK_N : nullptr;
 
       // do unpacking for the first row or a new expert
       int32_t pre_expert_id = mb == 0 ? -1 : expert_ids[mb - 1];
@@ -148,6 +176,7 @@ void fused_experts_fp8_kernel_impl(
           /*   C            */ C,
           /*   Btmp         */ B_tmp + tid * B_tmp_size_per_thread + nb_offset * BLOCK_N * IC,
           /*   Ctmp         */ C_tmp + tid * 2 * BLOCK_M * BLOCK_N,
+          /*   Bbias        */ B_bias,
           /*   scale        */ Bs,
           /*   M            */ m_size,
           /*   N            */ n_size,
@@ -182,35 +211,43 @@ void fused_experts_fp8_kernel_impl(
   });
 }
 
-#define INSTANTIATE_MOE_FP8_TEMPLATE(TYPE)             \
-  template void fused_experts_fp8_kernel_impl<TYPE>(   \
-      TYPE* __restrict__ output,                       \
-      TYPE* __restrict__ ic0,                          \
-      TYPE* __restrict__ ic1,                          \
-      TYPE* __restrict__ ic2,                          \
-      TYPE* __restrict__ A_tmp,                        \
-      TYPE* __restrict__ B_tmp,                        \
-      float* __restrict__ C_tmp,                       \
-      const TYPE* __restrict__ input,                  \
-      const at::Float8_e4m3fn* __restrict__ packed_w1, \
-      const at::Float8_e4m3fn* __restrict__ packed_w2, \
-      const float* __restrict__ w1s,                   \
-      const float* __restrict__ w2s,                   \
-      int64_t block_size_N,                            \
-      int64_t block_size_K,                            \
-      const float* __restrict__ topk_weights,          \
-      const int32_t* __restrict__ sorted_ids,          \
-      const int32_t* __restrict__ expert_ids,          \
-      const int32_t* __restrict__ offsets,             \
-      int64_t M,                                       \
-      int64_t N,                                       \
-      int64_t K,                                       \
-      int64_t E,                                       \
-      int64_t topk,                                    \
-      int64_t num_tokens_post_pad)
+#define INSTANTIATE_MOE_FP_TEMPLATE(TYPE1, TYPE2, TYPE3, IS_MXFP4)           \
+  template void fused_experts_fp_kernel_impl<TYPE1, TYPE2, TYPE3, IS_MXFP4>( \
+      TYPE1* __restrict__ output,                                            \
+      TYPE1* __restrict__ ic0,                                               \
+      TYPE1* __restrict__ ic1,                                               \
+      TYPE1* __restrict__ ic2,                                               \
+      TYPE1* __restrict__ A_tmp,                                             \
+      TYPE1* __restrict__ B_tmp,                                             \
+      float* __restrict__ C_tmp,                                             \
+      const TYPE1* __restrict__ input,                                       \
+      const TYPE2* __restrict__ packed_w1,                                   \
+      const TYPE2* __restrict__ packed_w2,                                   \
+      const float* __restrict__ w1_bias,                                     \
+      const float* __restrict__ w2_bias,                                     \
+      const TYPE3* __restrict__ w1s,                                         \
+      const TYPE3* __restrict__ w2s,                                         \
+      int64_t block_size_N,                                                  \
+      int64_t block_size_K,                                                  \
+      const float* __restrict__ topk_weights,                                \
+      const int32_t* __restrict__ sorted_ids,                                \
+      const int32_t* __restrict__ expert_ids,                                \
+      const int32_t* __restrict__ offsets,                                   \
+      int64_t M,                                                             \
+      int64_t N,                                                             \
+      int64_t K,                                                             \
+      int64_t E,                                                             \
+      int64_t topk,                                                          \
+      int64_t num_tokens_post_pad,                                           \
+      float alpha,                                                           \
+      float limit,                                                           \
+      CPUAcTMethod act_func,                                                 \
+      bool with_bias)
 
-INSTANTIATE_MOE_FP8_TEMPLATE(at::BFloat16);
-INSTANTIATE_MOE_FP8_TEMPLATE(at::Half);
+INSTANTIATE_MOE_FP_TEMPLATE(at::BFloat16, at::Float8_e4m3fn, float, false);
+INSTANTIATE_MOE_FP_TEMPLATE(at::Half, at::Float8_e4m3fn, float, false);
+INSTANTIATE_MOE_FP_TEMPLATE(at::BFloat16, uint8_t, uint8_t, true);
+INSTANTIATE_MOE_FP_TEMPLATE(at::Half, uint8_t, uint8_t, true);
 
 template <typename scalar_t>
 void shared_expert_fp8_kernel_impl(
@@ -261,6 +298,7 @@ void shared_expert_fp8_kernel_impl(
           /*   C            */ ic0 + mb * BLOCK_M * 2 * N + nb * BLOCK_N,
           /*   Btmp         */ B_tmp + tid * B_tmp_size_per_thread + nb_offset * BLOCK_N * K,
           /*   Ctmp         */ C_tmp + tid * 2 * BLOCK_M * BLOCK_N,
+          /*   Bbias        */ nullptr,
           /*   scale        */ w1s + (nb / blocks_n_per_group) * scale_size_K,
           /*   M            */ m_size,
           /*   N            */ n_size,
@@ -312,6 +350,7 @@ void shared_expert_fp8_kernel_impl(
           /*   C            */ C,
           /*   Btmp         */ B_tmp + tid * B_tmp_size_per_thread + nb_offset * BLOCK_N * IC,
           /*   Ctmp         */ C_tmp + tid * 2 * BLOCK_M * BLOCK_N,
+          /*   Bbias        */ nullptr,
           /*   scale        */ w2s + (nb / blocks_n_per_group) * scale_size_K,
           /*   M            */ m_size,
           /*   N            */ n_size,

--- a/sgl-kernel/csrc/cpu/moe_fp8.cpp
+++ b/sgl-kernel/csrc/cpu/moe_fp8.cpp
@@ -249,18 +249,18 @@ INSTANTIATE_MOE_FP_TEMPLATE(at::Half, at::Float8_e4m3fn, float, false);
 INSTANTIATE_MOE_FP_TEMPLATE(at::BFloat16, uint8_t, uint8_t, true);
 INSTANTIATE_MOE_FP_TEMPLATE(at::Half, uint8_t, uint8_t, true);
 
-template <typename scalar_t>
-void shared_expert_fp8_kernel_impl(
+template <typename scalar_t, typename packed_t, typename param_t, bool is_mxfp4>
+void shared_expert_fp_kernel_impl(
     scalar_t* __restrict__ output,
     scalar_t* __restrict__ ic0,
     scalar_t* __restrict__ ic1,
     scalar_t* __restrict__ B_tmp,
     float* __restrict__ C_tmp,
     const scalar_t* __restrict__ input,
-    const at::Float8_e4m3fn* __restrict__ packed_w1,
-    const at::Float8_e4m3fn* __restrict__ packed_w2,
-    const float* __restrict__ w1s,
-    const float* __restrict__ w2s,
+    const packed_t* __restrict__ packed_w1,
+    const packed_t* __restrict__ packed_w2,
+    const param_t* __restrict__ w1s,
+    const param_t* __restrict__ w2s,
     int64_t block_size_N,
     int64_t block_size_K,
     const scalar_t* __restrict__ fused_experts_out,
@@ -276,8 +276,15 @@ void shared_expert_fp8_kernel_impl(
   const int64_t NB = div_up(2 * N, BLOCK_N);
   int64_t scale_size_K = div_up(K, block_size_K);
   int64_t blocks_n_per_group = block_size_N / BLOCK_N;
+  std::function<int64_t(int64_t)> scale_offset_per_block;
+  if constexpr (is_mxfp4) {
+    scale_offset_per_block = [&](int64_t a) { return a * BLOCK_N; };
+  } else {
+    scale_offset_per_block = [&](int64_t a) { return a / blocks_n_per_group; };
+  }
 
-  const bool use_brgemm = can_use_brgemm<at::Float8_e4m3fn>(M);
+  const int64_t packed_K = get_row_size<packed_t>(K);
+  const bool use_brgemm = can_use_brgemm<packed_t>(M);
   const bool apply_scaling_factor = fused_experts_out != nullptr;
 
   int64_t B_tmp_size_per_thread = MAX_CACHE_BLOCK_SIZE * BLOCK_N * std::max(K, N);
@@ -285,7 +292,7 @@ void shared_expert_fp8_kernel_impl(
   parallel_2d(MB, NB, [&](int64_t mb0, int64_t mb1, int64_t nb0, int64_t nb1) {
     int tid = get_thread_num();
 
-    loop_2d<at::Float8_e4m3fn>(mb0, mb1, nb0, nb1, BLOCK_N * K, [&](int64_t mb, int64_t nb, int64_t nb_offset) {
+    loop_2d<packed_t>(mb0, mb1, nb0, nb1, BLOCK_N * K, [&](int64_t mb, int64_t nb, int64_t nb_offset) {
       int64_t m_size = std::min(M - mb * BLOCK_M, BLOCK_M);
       int64_t n_size = std::min(2 * N - nb * BLOCK_N, BLOCK_N);
 
@@ -294,12 +301,12 @@ void shared_expert_fp8_kernel_impl(
 
       tinygemm_kernel<scalar_t>(
           /*   A            */ input + mb * BLOCK_M * K,
-          /*   B            */ packed_w1 + nb * BLOCK_N * K,
+          /*   B            */ packed_w1 + nb * BLOCK_N * packed_K,
           /*   C            */ ic0 + mb * BLOCK_M * 2 * N + nb * BLOCK_N,
           /*   Btmp         */ B_tmp + tid * B_tmp_size_per_thread + nb_offset * BLOCK_N * K,
           /*   Ctmp         */ C_tmp + tid * 2 * BLOCK_M * BLOCK_N,
           /*   Bbias        */ nullptr,
-          /*   scale        */ w1s + (nb / blocks_n_per_group) * scale_size_K,
+          /*   scale        */ w1s + scale_offset_per_block(nb) * scale_size_K,
           /*   M            */ m_size,
           /*   N            */ n_size,
           /*   K            */ K,
@@ -330,13 +337,14 @@ void shared_expert_fp8_kernel_impl(
   const int64_t MB2 = MB;
   const int64_t NB2 = div_up(K, BLOCK_N);
   scale_size_K = div_up(N, block_size_K);
+  const int64_t packed_IC = get_row_size<packed_t>(IC);
 
   // parallel on [MB2, NB2]
   parallel_2d(MB2, NB2, [&](int64_t mb0, int64_t mb1, int64_t nb0, int64_t nb1) {
     int tid = get_thread_num();
     alignas(64) scalar_t C[BLOCK_M * BLOCK_K];
 
-    loop_2d<at::Float8_e4m3fn>(mb0, mb1, nb0, nb1, BLOCK_N * IC, [&](int64_t mb, int64_t nb, int64_t nb_offset) {
+    loop_2d<packed_t>(mb0, mb1, nb0, nb1, BLOCK_N * IC, [&](int64_t mb, int64_t nb, int64_t nb_offset) {
       int64_t m_size = std::min(M - mb * BLOCK_M, BLOCK_M);
       int64_t n_size = std::min(OC - nb * BLOCK_N, BLOCK_N);
 
@@ -346,12 +354,12 @@ void shared_expert_fp8_kernel_impl(
       // 2.a gemm: C = A @ B
       tinygemm_kernel<scalar_t>(
           /*   A            */ ic1 + mb * BLOCK_M * N,
-          /*   B            */ packed_w2 + nb * BLOCK_N * N,
+          /*   B            */ packed_w2 + nb * BLOCK_N * packed_IC,
           /*   C            */ C,
           /*   Btmp         */ B_tmp + tid * B_tmp_size_per_thread + nb_offset * BLOCK_N * IC,
           /*   Ctmp         */ C_tmp + tid * 2 * BLOCK_M * BLOCK_N,
           /*   Bbias        */ nullptr,
-          /*   scale        */ w2s + (nb / blocks_n_per_group) * scale_size_K,
+          /*   scale        */ w2s + scale_offset_per_block(nb) * scale_size_K,
           /*   M            */ m_size,
           /*   N            */ n_size,
           /*   K            */ IC,
@@ -378,25 +386,27 @@ void shared_expert_fp8_kernel_impl(
   }
 }
 
-#define INSTANTIATE_SHARED_EXPERT_FP8_TEMPLATE(TYPE)   \
-  template void shared_expert_fp8_kernel_impl<TYPE>(   \
-      TYPE* __restrict__ output,                       \
-      TYPE* __restrict__ ic0,                          \
-      TYPE* __restrict__ ic1,                          \
-      TYPE* __restrict__ B_tmp,                        \
-      float* __restrict__ C_tmp,                       \
-      const TYPE* __restrict__ input,                  \
-      const at::Float8_e4m3fn* __restrict__ packed_w1, \
-      const at::Float8_e4m3fn* __restrict__ packed_w2, \
-      const float* __restrict__ w1s,                   \
-      const float* __restrict__ w2s,                   \
-      int64_t block_size_N,                            \
-      int64_t block_size_K,                            \
-      const TYPE* __restrict__ fused_experts_out,      \
-      float routed_scaling_factor,                     \
-      int64_t M,                                       \
-      int64_t N,                                       \
+#define INSTANTIATE_SHARED_EXPERT_FP_TEMPLATE(TYPE1, TYPE2, TYPE3, IS_MXFP4) \
+  template void shared_expert_fp_kernel_impl<TYPE1, TYPE2, TYPE3, IS_MXFP4>( \
+      TYPE1* __restrict__ output,                                            \
+      TYPE1* __restrict__ ic0,                                               \
+      TYPE1* __restrict__ ic1,                                               \
+      TYPE1* __restrict__ B_tmp,                                             \
+      float* __restrict__ C_tmp,                                             \
+      const TYPE1* __restrict__ input,                                       \
+      const TYPE2* __restrict__ packed_w1,                                   \
+      const TYPE2* __restrict__ packed_w2,                                   \
+      const TYPE3* __restrict__ w1s,                                         \
+      const TYPE3* __restrict__ w2s,                                         \
+      int64_t block_size_N,                                                  \
+      int64_t block_size_K,                                                  \
+      const TYPE1* __restrict__ fused_experts_out,                           \
+      float routed_scaling_factor,                                           \
+      int64_t M,                                                             \
+      int64_t N,                                                             \
       int64_t K)
 
-INSTANTIATE_SHARED_EXPERT_FP8_TEMPLATE(at::BFloat16);
-INSTANTIATE_SHARED_EXPERT_FP8_TEMPLATE(at::Half);
+INSTANTIATE_SHARED_EXPERT_FP_TEMPLATE(at::BFloat16, at::Float8_e4m3fn, float, false);
+INSTANTIATE_SHARED_EXPERT_FP_TEMPLATE(at::Half, at::Float8_e4m3fn, float, false);
+INSTANTIATE_SHARED_EXPERT_FP_TEMPLATE(at::BFloat16, uint8_t, uint8_t, true);
+INSTANTIATE_SHARED_EXPERT_FP_TEMPLATE(at::Half, uint8_t, uint8_t, true);

--- a/sgl-kernel/csrc/cpu/moe_fp8.cpp
+++ b/sgl-kernel/csrc/cpu/moe_fp8.cpp
@@ -273,7 +273,10 @@ void shared_expert_fp_kernel_impl(
     float routed_scaling_factor,
     int64_t M,
     int64_t N,
-    int64_t K) {
+    int64_t K,
+    float alpha,
+    float limit,
+    CPUAcTMethod act_func) {
   constexpr int64_t BLOCK_M = block_size_m();
   constexpr int64_t BLOCK_N = block_size_n();
 
@@ -330,11 +333,26 @@ void shared_expert_fp_kernel_impl(
   });
 
   // stage 1.5: intermediate_cache1 = silu(intermediate_cache0)
-  at::parallel_for(0, M, 0, [&](int64_t begin, int64_t end) {
-    for (int64_t m = begin; m < end; ++m) {
-      silu_and_mul_stub(ic1 + m * N, ic0 + m * 2 * N, ic0 + m * 2 * N + N, N);
-    }
-  });
+  if (act_func == CPUAcTMethod::silu_and_mul) {
+    at::parallel_for(0, M, 0, [&](int64_t begin, int64_t end) {
+      for (int64_t m = begin; m < end; ++m) {
+        silu_and_mul_stub(ic1 + m * N, ic0 + m * 2 * N, ic0 + m * 2 * N + N, N);
+      }
+    });
+  } else if (act_func == CPUAcTMethod::clamped_silu_and_mul) {
+    at::parallel_for(0, M, 0, [&](int64_t begin, int64_t end) {
+      for (int64_t m = begin; m < end; ++m) {
+        clamped_silu_and_mul_stub(ic1 + m * N, ic0 + m * 2 * N, ic0 + m * 2 * N + N, N, limit);
+      }
+    });
+  } else if (act_func == CPUAcTMethod::swiglu) {
+    at::parallel_for(0, M, 0, [&](int64_t begin, int64_t end) {
+      for (int64_t m = begin; m < end; ++m) {
+        clamp_sigmoid_and_mul_stub(ic1 + m * N, ic0 + m * 2 * N, N, alpha, limit);
+        clamp_sigmoid_and_mul_stub(ic1 + m * N + N / 2, ic0 + m * 2 * N + N, N, alpha, limit);
+      }
+    });
+  }
 
   // stage 2: intermediate_cache2 = intermediate_cache1 @ w2
   //   w2 : [K, N] as [OC, IC]
@@ -410,7 +428,10 @@ void shared_expert_fp_kernel_impl(
       float routed_scaling_factor,                                           \
       int64_t M,                                                             \
       int64_t N,                                                             \
-      int64_t K)
+      int64_t K,                                                             \
+      float alpha,                                                           \
+      float limit,                                                           \
+      CPUAcTMethod act_func)
 
 INSTANTIATE_SHARED_EXPERT_FP_TEMPLATE(at::BFloat16, at::Float8_e4m3fn, float, false);
 INSTANTIATE_SHARED_EXPERT_FP_TEMPLATE(at::Half, at::Float8_e4m3fn, float, false);

--- a/sgl-kernel/csrc/cpu/moe_fp8.cpp
+++ b/sgl-kernel/csrc/cpu/moe_fp8.cpp
@@ -124,6 +124,12 @@ void fused_experts_fp_kernel_impl(
         silu_and_mul_stub(ic1 + m * N, ic0 + m * 2 * N, ic0 + m * 2 * N + N, N);
       }
     });
+  } else if (act_func == CPUAcTMethod::clamped_silu_and_mul) {
+    at::parallel_for(0, M * topk, 0, [&](int64_t begin, int64_t end) {
+      for (int64_t m = begin; m < end; ++m) {
+        clamped_silu_and_mul_stub(ic1 + m * N, ic0 + m * 2 * N, ic0 + m * 2 * N + N, N, limit);
+      }
+    });
   } else if (act_func == CPUAcTMethod::swiglu) {
     at::parallel_for(0, M * topk, 0, [&](int64_t begin, int64_t end) {
       for (int64_t m = begin; m < end; ++m) {

--- a/sgl-kernel/csrc/cpu/qkv_proj.cpp
+++ b/sgl-kernel/csrc/cpu/qkv_proj.cpp
@@ -210,6 +210,7 @@ void segment_gemm_kernel_impl(
           /*   C */ C + mb_start * ldc + local_nb_start,
           /* Btmp*/ Btmp + tid * BLOCK_N * K,
           /* Ctmp*/ Ctmp,
+          /*Bbias*/ nullptr,
           /*  Bs */ Bs + (new_nb / blocks_n_per_group) * scale_size_K,
           /*   M */ mb_size,
           /*   N */ nb_size,

--- a/sgl-kernel/csrc/cpu/qkv_proj.cpp
+++ b/sgl-kernel/csrc/cpu/qkv_proj.cpp
@@ -387,7 +387,12 @@ void rotary_emb_kernel_impl(
 }  // anonymous namespace
 
 extern at::Tensor
-weight_packed_linear(at::Tensor& mat1, at::Tensor& mat2, const std::optional<at::Tensor>& bias, bool is_vnni);
+weight_packed_linear(
+    at::Tensor& mat1,
+    at::Tensor& mat2,
+    const std::optional<at::Tensor>& bias,
+    bool is_vnni,
+    std::optional<at::ScalarType> out_dtype = c10::nullopt);
 
 extern at::Tensor int8_scaled_mm_with_quant(
     at::Tensor& mat1,

--- a/sgl-kernel/csrc/cpu/store_cache.cpp
+++ b/sgl-kernel/csrc/cpu/store_cache.cpp
@@ -292,6 +292,64 @@ void set_k_and_s_cpu(
 }
 
 
+// set_k_cpu: scatter-copy index key data (fp8, viewed as uint8) into
+// a paged buffer for NSA (non-sparse attention) index cache.
+//
+// Buffer layout per page (buf shape: [num_pages, buf_numel_per_page]):
+//   K data region: page_size * index_head_dim bytes (fp8 key data)
+//   S data region: page_size * 4 bytes (fp32 scale per token)
+//
+// index_k is fp8 (index_head_dim elements per token), stored as raw bytes.
+//
+void set_k_cpu(
+    at::Tensor& buf,       // [num_pages, buf_numel_per_page], uint8
+    at::Tensor& loc,       // [num_tokens], int32 or int64
+    at::Tensor& index_k,   // [num_tokens, index_head_dim], fp8 (viewed as uint8)
+    int64_t page_size,
+    int64_t index_head_dim) {
+  const int64_t num_tokens = loc.size(0);
+  const int64_t buf_numel_per_page = buf.size(1);
+  const int64_t num_k_bytes_per_token = index_head_dim;
+
+  uint8_t* buf_ptr = buf.data_ptr<uint8_t>();
+  const uint8_t* k_ptr = reinterpret_cast<const uint8_t*>(index_k.data_ptr());
+
+  const bool loc_is_int64 = (loc.scalar_type() == at::kLong);
+  const int32_t* loc_i32 = loc_is_int64 ? nullptr : loc.data_ptr<int32_t>();
+  const int64_t* loc_i64 = loc_is_int64 ? loc.data_ptr<int64_t>() : nullptr;
+
+  at::parallel_for(0, num_tokens, 0, [&](int64_t begin, int64_t end) {
+    for (int64_t i = begin; i < end; ++i) {
+      const int64_t token_loc = loc_is_int64 ? loc_i64[i] : static_cast<int64_t>(loc_i32[i]);
+      const int64_t page_idx = token_loc / page_size;
+      const int64_t token_off = token_loc % page_size;
+
+      const int64_t dst_offset =
+          page_idx * buf_numel_per_page + token_off * num_k_bytes_per_token;
+
+      uint8_t* dst = buf_ptr + dst_offset;
+      const uint8_t* src = k_ptr + i * num_k_bytes_per_token;
+
+#if defined(CPU_CAPABILITY_AVX512)
+      // index_head_dim=128: 2 x 64-byte AVX512 stores
+      {
+        int64_t d = 0;
+        for (; d + 64 <= num_k_bytes_per_token; d += 64) {
+          __m512i v = _mm512_loadu_si512(reinterpret_cast<const __m512i*>(src + d));
+          _mm512_storeu_si512(reinterpret_cast<__m512i*>(dst + d), v);
+        }
+        if (d < num_k_bytes_per_token) {
+          std::memcpy(dst + d, src + d, num_k_bytes_per_token - d);
+        }
+      }
+#else
+      std::memcpy(dst, src, num_k_bytes_per_token);
+#endif
+    }
+  });
+}
+
+
 // set_s_cpu: scatter-copy scale values (fp32, viewed as 4 bytes uint8)
 // into a paged buffer for NSA (non-sparse attention) index cache.
 //

--- a/sgl-kernel/csrc/cpu/store_cache.cpp
+++ b/sgl-kernel/csrc/cpu/store_cache.cpp
@@ -1,0 +1,342 @@
+#include "common.h"
+#include <cmath>
+#include <cstring>
+#include <immintrin.h>
+
+
+// ============================================================================
+// quant_to_nope_fp8_rope_bf16_pack_cpu
+//
+// Equivalent to Python:
+//   k_nope_bf16, k_rope_bf16 = k_bf16.split([448, 64], dim=-1)
+//   x = k_nope_bf16.view(-1, 7, 64)
+//   scale = x.abs().amax(dim=-1).float() / 448.0
+//   scale_pow2 = 2^ceil(log2(max(scale, 1e-4)))
+//   k_nope_fp8 = (x.float() / scale_pow2.unsqueeze(-1)).to(fp8_e4m3fn)
+//   scale_uint8 = e8m0_encode(scale_pow2) -> (ceil_log2 + 127)
+// ============================================================================
+
+namespace {
+
+constexpr int64_t QUANT_DIM_NOPE = 448;
+constexpr int64_t QUANT_DIM_ROPE = 64;
+constexpr int64_t QUANT_TILE_SIZE = 64;
+constexpr int64_t QUANT_NUM_TILES = QUANT_DIM_NOPE / QUANT_TILE_SIZE;  // 7
+constexpr float QUANT_FP8_MAX = 448.0f;
+constexpr float QUANT_FP8_MIN = -448.0f;
+constexpr float QUANT_EPS = 1e-4f;
+
+// Float to fp8_e4m3fn using PyTorch's conversion (scalar fallback)
+inline uint8_t float_to_fp8_e4m3fn(float val) {
+  return at::Float8_e4m3fn(val).x;
+}
+
+#if defined(CPU_CAPABILITY_AVX512)
+
+// Vectorized float32x16 -> fp8_e4m3fn x16 using AVX512 bit manipulation.
+// Implements RNE (round-to-nearest-even). Flushes subnormal fp8 to zero
+// (safe because SGLANG_CPU_FP8_CVT_FTZ flushes them on decode too).
+// fp8_e4m3fn: sign(1), exp(4, bias=7), mant(3), no inf/nan special values.
+// Normal: exp_field in [1..15], value = 2^(exp-7) * (1 + mant/8)
+// Input assumed clamped to [-448, 448].
+inline __m128i cvt_fp32x16_to_fp8x16(__m512 input) {
+  __m512i bits = _mm512_castps_si512(input);
+
+  // Extract sign -> bit 7 of fp8 byte
+  __m512i signs = _mm512_srli_epi32(_mm512_and_si512(bits, _mm512_set1_epi32(0x80000000)), 24);
+
+  // Absolute value bits
+  __m512i abs_bits = _mm512_and_si512(bits, _mm512_set1_epi32(0x7FFFFFFF));
+
+  // Float32 biased exponent
+  __m512i f32_exp = _mm512_srli_epi32(abs_bits, 23);
+
+  // Float32 mantissa (23 bits)
+  __m512i f32_mant = _mm512_and_si512(abs_bits, _mm512_set1_epi32(0x7FFFFF));
+
+  // fp8_exp = f32_exp - 120 (rebias from 127 to 7)
+  __m512i fp8_exp = _mm512_sub_epi32(f32_exp, _mm512_set1_epi32(120));
+
+  // Top 3 mantissa bits
+  __m512i mant3 = _mm512_srli_epi32(f32_mant, 20);
+
+  // RNE rounding: round_bit = bit 19, sticky = bits[18:0]
+  __m512i round_bit = _mm512_and_si512(_mm512_srli_epi32(f32_mant, 19), _mm512_set1_epi32(1));
+  __m512i sticky_bits = _mm512_and_si512(f32_mant, _mm512_set1_epi32(0x7FFFF));
+  __mmask16 has_sticky = _mm512_cmpneq_epi32_mask(sticky_bits, _mm512_setzero_si512());
+
+  // Round up if round_bit AND (sticky OR lsb_of_mant3)
+  __m512i lsb = _mm512_and_si512(mant3, _mm512_set1_epi32(1));
+  __m512i sticky_or_lsb = _mm512_or_si512(
+      _mm512_maskz_mov_epi32(has_sticky, _mm512_set1_epi32(1)), lsb);
+  __m512i do_round = _mm512_and_si512(round_bit, sticky_or_lsb);
+  mant3 = _mm512_add_epi32(mant3, do_round);
+
+  // Mantissa overflow (mant3 == 8) -> increment exponent, zero mantissa
+  __mmask16 mant_ovf = _mm512_cmpeq_epi32_mask(mant3, _mm512_set1_epi32(8));
+  mant3 = _mm512_mask_mov_epi32(mant3, mant_ovf, _mm512_setzero_si512());
+  fp8_exp = _mm512_mask_add_epi32(fp8_exp, mant_ovf, fp8_exp, _mm512_set1_epi32(1));
+
+  // Clamp exponent: max 15
+  fp8_exp = _mm512_min_epi32(fp8_exp, _mm512_set1_epi32(15));
+
+  // Result: (fp8_exp << 3) | mant3
+  __m512i result = _mm512_or_si512(_mm512_slli_epi32(fp8_exp, 3), mant3);
+
+  // Flush to zero: if f32_exp < 121 (would be subnormal in fp8), output 0
+  __mmask16 is_subnormal_or_zero = _mm512_cmplt_epi32_mask(f32_exp, _mm512_set1_epi32(121));
+  result = _mm512_mask_mov_epi32(result, is_subnormal_or_zero, _mm512_setzero_si512());
+
+  // Add sign
+  result = _mm512_or_si512(result, signs);
+
+  // Pack 16 x i32 -> 16 x i8
+  return _mm512_cvtepi32_epi8(result);
+}
+
+// Process one tile (64 bf16 values): find amax, compute scale, quantize to fp8
+inline uint8_t quantize_tile_avx512(
+    const at::BFloat16* __restrict__ src,
+    uint8_t* __restrict__ dst) {
+
+  // Load 64 bf16 -> 4 x 16 floats
+  __m256i bf16_0 = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(src));
+  __m256i bf16_1 = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(src + 16));
+  __m256i bf16_2 = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(src + 32));
+  __m256i bf16_3 = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(src + 48));
+
+  __m512 f0 = _mm512_castsi512_ps(_mm512_slli_epi32(_mm512_cvtepu16_epi32(bf16_0), 16));
+  __m512 f1 = _mm512_castsi512_ps(_mm512_slli_epi32(_mm512_cvtepu16_epi32(bf16_1), 16));
+  __m512 f2 = _mm512_castsi512_ps(_mm512_slli_epi32(_mm512_cvtepu16_epi32(bf16_2), 16));
+  __m512 f3 = _mm512_castsi512_ps(_mm512_slli_epi32(_mm512_cvtepu16_epi32(bf16_3), 16));
+
+  // Absolute values
+  const __m512i abs_mask_i = _mm512_set1_epi32(0x7FFFFFFF);
+  __m512 abs0 = _mm512_castsi512_ps(_mm512_and_si512(_mm512_castps_si512(f0), abs_mask_i));
+  __m512 abs1 = _mm512_castsi512_ps(_mm512_and_si512(_mm512_castps_si512(f1), abs_mask_i));
+  __m512 abs2 = _mm512_castsi512_ps(_mm512_and_si512(_mm512_castps_si512(f2), abs_mask_i));
+  __m512 abs3 = _mm512_castsi512_ps(_mm512_and_si512(_mm512_castps_si512(f3), abs_mask_i));
+
+  // Horizontal max
+  __m512 max01 = _mm512_max_ps(abs0, abs1);
+  __m512 max23 = _mm512_max_ps(abs2, abs3);
+  __m512 max0123 = _mm512_max_ps(max01, max23);
+  float amax = _mm512_reduce_max_ps(max0123);
+
+  // Scale computation
+  float scale = std::max(amax / QUANT_FP8_MAX, QUANT_EPS);
+  float ceil_log2 = std::ceil(std::log2(scale));
+  float scale_pow2 = std::exp2(ceil_log2);
+  float scale_inv = 1.0f / scale_pow2;
+
+  int exponent = static_cast<int>(ceil_log2);
+  uint8_t scale_uint8 = static_cast<uint8_t>(exponent + 127);
+
+  // Scale all values
+  __m512 vinv = _mm512_set1_ps(scale_inv);
+  __m512 s0 = _mm512_mul_ps(f0, vinv);
+  __m512 s1 = _mm512_mul_ps(f1, vinv);
+  __m512 s2 = _mm512_mul_ps(f2, vinv);
+  __m512 s3 = _mm512_mul_ps(f3, vinv);
+
+  // Clamp
+  __m512 vmax = _mm512_set1_ps(QUANT_FP8_MAX);
+  __m512 vmin = _mm512_set1_ps(QUANT_FP8_MIN);
+  s0 = _mm512_max_ps(_mm512_min_ps(s0, vmax), vmin);
+  s1 = _mm512_max_ps(_mm512_min_ps(s1, vmax), vmin);
+  s2 = _mm512_max_ps(_mm512_min_ps(s2, vmax), vmin);
+  s3 = _mm512_max_ps(_mm512_min_ps(s3, vmax), vmin);
+
+  // Vectorized float -> fp8 conversion (16 values at a time)
+  __m128i fp8_0 = cvt_fp32x16_to_fp8x16(s0);
+  __m128i fp8_1 = cvt_fp32x16_to_fp8x16(s1);
+  __m128i fp8_2 = cvt_fp32x16_to_fp8x16(s2);
+  __m128i fp8_3 = cvt_fp32x16_to_fp8x16(s3);
+
+  _mm_storeu_si128(reinterpret_cast<__m128i*>(dst), fp8_0);
+  _mm_storeu_si128(reinterpret_cast<__m128i*>(dst + 16), fp8_1);
+  _mm_storeu_si128(reinterpret_cast<__m128i*>(dst + 32), fp8_2);
+  _mm_storeu_si128(reinterpret_cast<__m128i*>(dst + 48), fp8_3);
+
+  return scale_uint8;
+}
+
+#endif  // CPU_CAPABILITY_AVX512
+
+inline uint8_t quantize_tile_scalar(
+    const at::BFloat16* __restrict__ src,
+    uint8_t* __restrict__ dst) {
+
+  float amax = 0.0f;
+  for (int j = 0; j < QUANT_TILE_SIZE; ++j) {
+    float v = std::abs(static_cast<float>(src[j]));
+    if (v > amax) amax = v;
+  }
+
+  float scale = std::max(amax / QUANT_FP8_MAX, QUANT_EPS);
+  float ceil_log2 = std::ceil(std::log2(scale));
+  float scale_pow2 = std::exp2(ceil_log2);
+  float scale_inv = 1.0f / scale_pow2;
+
+  int exponent = static_cast<int>(ceil_log2);
+  uint8_t scale_uint8 = static_cast<uint8_t>(exponent + 127);
+
+  for (int j = 0; j < QUANT_TILE_SIZE; ++j) {
+    float val = static_cast<float>(src[j]) * scale_inv;
+    val = std::max(std::min(val, QUANT_FP8_MAX), QUANT_FP8_MIN);
+    dst[j] = float_to_fp8_e4m3fn(val);
+  }
+
+  return scale_uint8;
+}
+
+}  // anonymous namespace
+
+// set_k_and_s_cpu: scatter-copy k_nope (fp8), k_rope (bf16), and
+// scale_k_nope (uint8) into a paged KV-cache buffer.
+//
+// Buffer layout per page (buf shape: [num_pages, buf_numel_per_page]):
+//   Token data region: page_size * (nope_dim + rope_dim*2) bytes
+//     Per token: [nope_dim bytes fp8 | rope_dim*2 bytes bf16]
+//   Scale region: page_size * (scale_dim + 1) bytes
+//     Per token: [scale_dim bytes | 1 byte padding]
+//
+void set_k_and_s_cpu(
+    at::Tensor& buf,         // [num_pages, buf_numel_per_page], uint8
+    at::Tensor& loc,         // [num_tokens], int32 or int64
+    at::Tensor& k_nope,      // [num_tokens, nope_dim], fp8 (viewed as uint8)
+    at::Tensor& k_rope,      // [num_tokens, rope_dim], bf16 (viewed as uint8, rope_dim*2 bytes)
+    at::Tensor& scale_k_nope,// [num_tokens, scale_dim], uint8
+    int64_t page_size) {
+  const int64_t num_tokens = loc.size(0);
+  const int64_t buf_numel_per_page = buf.size(1);
+  const int64_t nope_dim = k_nope.size(1);       // 448 (bytes, fp8 elements)
+  const int64_t rope_dim = k_rope.size(1);        // 64 (bf16 elements, 128 bytes)
+  const int64_t scale_dim = scale_k_nope.size(1); // 7
+
+  const int64_t nope_rope_bytes = nope_dim + rope_dim * 2;
+  const int64_t s_offset_nbytes_in_page = page_size * nope_rope_bytes;
+  const int64_t padded_scale_per_token = scale_dim + 1;
+
+  uint8_t* buf_ptr = buf.data_ptr<uint8_t>();
+  const uint8_t* k_nope_ptr = reinterpret_cast<const uint8_t*>(k_nope.data_ptr());
+  const uint8_t* k_rope_ptr = reinterpret_cast<const uint8_t*>(k_rope.data_ptr());
+  const uint8_t* scale_ptr = scale_k_nope.data_ptr<uint8_t>();
+
+  // We handle both int32 and int64 loc
+  const bool loc_is_int64 = (loc.scalar_type() == at::kLong);
+  const int32_t* loc_i32 = loc_is_int64 ? nullptr : loc.data_ptr<int32_t>();
+  const int64_t* loc_i64 = loc_is_int64 ? loc.data_ptr<int64_t>() : nullptr;
+
+  at::parallel_for(0, num_tokens, 0, [&](int64_t begin, int64_t end) {
+    for (int64_t i = begin; i < end; ++i) {
+      const int64_t token_loc = loc_is_int64 ? loc_i64[i] : static_cast<int64_t>(loc_i32[i]);
+      const int64_t page_idx = token_loc / page_size;
+      const int64_t token_off = token_loc % page_size;
+
+      // --- nope: copy nope_dim bytes (fp8) ---
+      const int64_t nope_byte_offset =
+          page_idx * buf_numel_per_page + token_off * nope_rope_bytes;
+      uint8_t* dst_nope = buf_ptr + nope_byte_offset;
+      const uint8_t* src_nope = k_nope_ptr + i * nope_dim;
+
+#if defined(CPU_CAPABILITY_AVX512)
+      // nope_dim=448: 7 x 64-byte AVX512 stores
+      {
+        int64_t d = 0;
+        for (; d + 64 <= nope_dim; d += 64) {
+          __m512i v = _mm512_loadu_si512(reinterpret_cast<const __m512i*>(src_nope + d));
+          _mm512_storeu_si512(reinterpret_cast<__m512i*>(dst_nope + d), v);
+        }
+        // Handle remainder (nope_dim % 64 == 0 for 448, but be safe)
+        if (d < nope_dim) {
+          std::memcpy(dst_nope + d, src_nope + d, nope_dim - d);
+        }
+      }
+#else
+      std::memcpy(dst_nope, src_nope, nope_dim);
+#endif
+
+      // --- rope: copy rope_dim bf16 values = rope_dim*2 bytes ---
+      const int64_t rope_byte_offset =
+          page_idx * buf_numel_per_page + token_off * nope_rope_bytes + nope_dim;
+      uint8_t* dst_rope = buf_ptr + rope_byte_offset;
+      const uint8_t* src_rope = k_rope_ptr + i * rope_dim * 2;
+      const int64_t rope_bytes = rope_dim * 2;
+
+#if defined(CPU_CAPABILITY_AVX512)
+      // rope_bytes=128: 2 x 64-byte AVX512 stores
+      {
+        int64_t d = 0;
+        for (; d + 64 <= rope_bytes; d += 64) {
+          __m512i v = _mm512_loadu_si512(reinterpret_cast<const __m512i*>(src_rope + d));
+          _mm512_storeu_si512(reinterpret_cast<__m512i*>(dst_rope + d), v);
+        }
+        if (d < rope_bytes) {
+          std::memcpy(dst_rope + d, src_rope + d, rope_bytes - d);
+        }
+      }
+#else
+      std::memcpy(dst_rope, src_rope, rope_bytes);
+#endif
+
+      // --- scale: copy scale_dim bytes ---
+      const int64_t s_byte_offset =
+          page_idx * buf_numel_per_page + s_offset_nbytes_in_page
+          + token_off * padded_scale_per_token;
+      uint8_t* dst_scale = buf_ptr + s_byte_offset;
+      const uint8_t* src_scale = scale_ptr + i * scale_dim;
+      std::memcpy(dst_scale, src_scale, scale_dim);
+    }
+  });
+}
+
+
+std::tuple<at::Tensor, at::Tensor, at::Tensor>
+quant_to_nope_fp8_rope_bf16_pack_cpu(at::Tensor& k_bf16) {
+  TORCH_CHECK(k_bf16.dtype() == at::kBFloat16,
+      "quant_to_nope_fp8_rope_bf16_pack_cpu: expect bf16 input, got ", k_bf16.dtype());
+  TORCH_CHECK(k_bf16.dim() == 2 && k_bf16.size(1) == 512,
+      "quant_to_nope_fp8_rope_bf16_pack_cpu: expect input shape [N, 512]");
+  TORCH_CHECK(k_bf16.is_contiguous(),
+      "quant_to_nope_fp8_rope_bf16_pack_cpu: expect contiguous input");
+
+  const int64_t num_tokens = k_bf16.size(0);
+
+  auto k_nope_fp8 = at::empty({num_tokens, QUANT_DIM_NOPE},
+      k_bf16.options().dtype(at::kFloat8_e4m3fn));
+  auto k_rope_bf16 = at::empty({num_tokens, QUANT_DIM_ROPE},
+      k_bf16.options().dtype(at::kBFloat16));
+  auto scale_out = at::empty({num_tokens, QUANT_NUM_TILES},
+      k_bf16.options().dtype(at::kByte));
+
+  const at::BFloat16* input_ptr = k_bf16.data_ptr<at::BFloat16>();
+  uint8_t* nope_ptr = reinterpret_cast<uint8_t*>(k_nope_fp8.data_ptr());
+  at::BFloat16* rope_ptr = k_rope_bf16.data_ptr<at::BFloat16>();
+  uint8_t* scale_ptr = scale_out.data_ptr<uint8_t>();
+
+  at::parallel_for(0, num_tokens, 0, [&](int64_t begin, int64_t end) {
+    for (int64_t t = begin; t < end; ++t) {
+      const at::BFloat16* src_token = input_ptr + t * 512;
+
+      // Copy rope portion (last 64 bf16 values = 128 bytes)
+      std::memcpy(rope_ptr + t * QUANT_DIM_ROPE,
+                  src_token + QUANT_DIM_NOPE,
+                  QUANT_DIM_ROPE * sizeof(at::BFloat16));
+
+      // Quantize each nope tile
+      for (int64_t tile = 0; tile < QUANT_NUM_TILES; ++tile) {
+        const at::BFloat16* tile_src = src_token + tile * QUANT_TILE_SIZE;
+        uint8_t* tile_dst = nope_ptr + t * QUANT_DIM_NOPE + tile * QUANT_TILE_SIZE;
+
+#if defined(CPU_CAPABILITY_AVX512)
+        scale_ptr[t * QUANT_NUM_TILES + tile] = quantize_tile_avx512(tile_src, tile_dst);
+#else
+        scale_ptr[t * QUANT_NUM_TILES + tile] = quantize_tile_scalar(tile_src, tile_dst);
+#endif
+      }
+    }
+  });
+
+  return std::make_tuple(k_nope_fp8, k_rope_bf16, scale_out);
+}

--- a/sgl-kernel/csrc/cpu/store_cache.cpp
+++ b/sgl-kernel/csrc/cpu/store_cache.cpp
@@ -292,6 +292,57 @@ void set_k_and_s_cpu(
 }
 
 
+// set_s_cpu: scatter-copy scale values (fp32, viewed as 4 bytes uint8)
+// into a paged buffer for NSA (non-sparse attention) index cache.
+//
+// Buffer layout per page (buf shape: [num_pages, buf_numel_per_page]):
+//   K data region: page_size * index_head_dim bytes (fp8 key data)
+//   S data region: page_size * 4 bytes (fp32 scale per token)
+//
+// index_k_scale is fp32 (1 per token), stored as 4 raw bytes in the buffer.
+//
+void set_s_cpu(
+    at::Tensor& buf,            // [num_pages, buf_numel_per_page], uint8
+    at::Tensor& loc,            // [num_tokens], int32 or int64
+    at::Tensor& index_k_scale,  // [num_tokens] or [num_tokens, 1], fp32
+    int64_t page_size,
+    int64_t index_head_dim) {
+  // Flatten index_k_scale to 1D if needed
+  auto scale_flat = index_k_scale.dim() == 2 ? index_k_scale.squeeze(1) : index_k_scale;
+
+  const int64_t num_tokens = loc.size(0);
+  const int64_t buf_numel_per_page = buf.size(1);
+  const int64_t num_s_bytes_per_token = 4;  // fp32 = 4 bytes
+  const int64_t s_offset_in_page = page_size * index_head_dim;
+
+  uint8_t* buf_ptr = buf.data_ptr<uint8_t>();
+  const uint8_t* scale_ptr = reinterpret_cast<const uint8_t*>(scale_flat.data_ptr<float>());
+
+  const bool loc_is_int64 = (loc.scalar_type() == at::kLong);
+  const int32_t* loc_i32 = loc_is_int64 ? nullptr : loc.data_ptr<int32_t>();
+  const int64_t* loc_i64 = loc_is_int64 ? loc.data_ptr<int64_t>() : nullptr;
+
+  at::parallel_for(0, num_tokens, 0, [&](int64_t begin, int64_t end) {
+    for (int64_t i = begin; i < end; ++i) {
+      const int64_t token_loc = loc_is_int64 ? loc_i64[i] : static_cast<int64_t>(loc_i32[i]);
+      const int64_t page_idx = token_loc / page_size;
+      const int64_t token_off = token_loc % page_size;
+
+      const int64_t dst_offset =
+          page_idx * buf_numel_per_page
+          + s_offset_in_page
+          + token_off * num_s_bytes_per_token;
+
+      uint8_t* dst = buf_ptr + dst_offset;
+      const uint8_t* src = scale_ptr + i * num_s_bytes_per_token;
+
+      // 4-byte copy: use 32-bit integer copy for efficiency
+      *reinterpret_cast<uint32_t*>(dst) = *reinterpret_cast<const uint32_t*>(src);
+    }
+  });
+}
+
+
 std::tuple<at::Tensor, at::Tensor, at::Tensor>
 quant_to_nope_fp8_rope_bf16_pack_cpu(at::Tensor& k_bf16) {
   TORCH_CHECK(k_bf16.dtype() == at::kBFloat16,

--- a/sgl-kernel/csrc/cpu/topk.cpp
+++ b/sgl-kernel/csrc/cpu/topk.cpp
@@ -3,7 +3,7 @@
 
 namespace {
 
-template <typename scalar_t, int SIZE>
+template <typename scalar_t, int SIZE, std::enable_if_t<!std::is_same_v<scalar_t, float>, int> = 0>
 inline void softmax(float* __restrict__ out, const scalar_t* __restrict__ input) {
   using bVec = at::vec::Vectorized<scalar_t>;
   using fVec = at::vec::Vectorized<float>;
@@ -63,6 +63,39 @@ inline void softmax(float* __restrict__ out, const scalar_t* __restrict__ input)
       fVec out_fvec = fVec::loadu(out + d) * sum_fvec;
       out_fvec.store(out + d);
     }
+  }
+}
+
+template <typename scalar_t, int SIZE, std::enable_if_t<std::is_same_v<scalar_t, float>, int> = 0>
+inline void softmax(float* __restrict__ out, const float* __restrict__ input) {
+  using fVec = at::vec::Vectorized<float>;
+
+  constexpr int kVecSize = fVec::size();
+
+  // step 1: get max
+  fVec max_fvec = fVec(-std::numeric_limits<float>::infinity());
+  for (int d = 0; d < SIZE; d += kVecSize) {
+    fVec x_fvec = fVec::loadu(input + d);
+    max_fvec = at::vec::maximum(max_fvec, x_fvec);
+    x_fvec.store(out + d);
+  }
+  float max_val = vec_reduce_max(max_fvec);
+  max_fvec = fVec(max_val);
+
+  // step 2: sum of (x - max).exp()
+  fVec sum_fvec = fVec(float(0));
+  for (int d = 0; d < SIZE; d += kVecSize) {
+    fVec x_fvec = (fVec::loadu(out + d) - max_fvec).exp_u20();
+    sum_fvec += x_fvec;
+    x_fvec.store(out + d);
+  }
+  float sum_val = vec_reduce_sum(sum_fvec);
+
+  // step 3: x * (1 / sum)
+  sum_fvec = fVec(1.f / sum_val);
+  for (int d = 0; d < SIZE; d += kVecSize) {
+    fVec out_fvec = fVec::loadu(out + d) * sum_fvec;
+    out_fvec.store(out + d);
   }
 }
 
@@ -404,6 +437,266 @@ void biased_grouped_topk_kernel_impl(
   });
 }
 
+// sqrtsoftplus: sqrt(softplus(x)) = sqrt(log(1 + exp(x)))
+// For numerical stability: when x > threshold, softplus(x) ≈ x
+// When x < -threshold, softplus(x) ≈ exp(x), so sqrt(softplus(x)) ≈ sqrt(exp(x)) = exp(x/2)
+template <typename scalar_t, int SIZE, std::enable_if_t<!std::is_same_v<scalar_t, float>, int> = 0>
+inline void sqrtsoftplus(float* __restrict__ out, const scalar_t* __restrict__ input) {
+  using bVec = at::vec::Vectorized<scalar_t>;
+  using fVec = at::vec::Vectorized<float>;
+
+  const fVec one = fVec(1.f);
+  const fVec half = fVec(0.5f);
+  const fVec threshold = fVec(20.f);
+  const fVec neg_threshold = fVec(-15.f);  // below this, 1+exp(x) loses precision in float32
+
+  constexpr int kVecSize = bVec::size();
+  for (int d = 0; d < SIZE; d += kVecSize) {
+    bVec x_bvec = bVec::loadu(input + d);
+    fVec x_fvec0, x_fvec1;
+    std::tie(x_fvec0, x_fvec1) = at::vec::convert_to_float(x_bvec);
+
+    // default: softplus(x) = log(1 + exp(x))
+    fVec sp0 = (one + x_fvec0.exp_u20()).log();
+    fVec sp1 = (one + x_fvec1.exp_u20()).log();
+    // x > 20: softplus(x) ≈ x
+    sp0 = fVec::blendv(sp0, x_fvec0, x_fvec0 > threshold);
+    sp1 = fVec::blendv(sp1, x_fvec1, x_fvec1 > threshold);
+    // x < -15: softplus(x) ≈ exp(x), sqrt(exp(x)) = exp(x/2)
+    fVec exp_half0 = (x_fvec0 * half).exp_u20();
+    fVec exp_half1 = (x_fvec1 * half).exp_u20();
+    sp0 = fVec::blendv(sp0.sqrt(), exp_half0, x_fvec0 < neg_threshold);
+    sp1 = fVec::blendv(sp1.sqrt(), exp_half1, x_fvec1 < neg_threshold);
+
+    sp0.store(out + d);
+    sp1.store(out + d + fVec::size());
+  }
+}
+
+template <typename scalar_t, int SIZE, std::enable_if_t<std::is_same_v<scalar_t, float>, int> = 0>
+inline void sqrtsoftplus(float* __restrict__ out, const float* __restrict__ input) {
+  using fVec = at::vec::Vectorized<float>;
+  const fVec one = fVec(1.f);
+  const fVec half = fVec(0.5f);
+  const fVec threshold = fVec(20.f);
+  const fVec neg_threshold = fVec(-15.f);
+  constexpr int kVecSize = fVec::size();
+  for (int d = 0; d < SIZE; d += kVecSize) {
+    fVec x = fVec::loadu(input + d);
+    fVec sp = (one + x.exp_u20()).log();
+    sp = fVec::blendv(sp, x, x > threshold);
+    fVec exp_half = (x * half).exp_u20();
+    sp = fVec::blendv(sp.sqrt(), exp_half, x < neg_threshold);
+    sp.store(out + d);
+  }
+}
+
+// biased_topk: flat (non-grouped) biased topk for DeepSeek V4
+// scoring_func: 0 = sigmoid, 1 = sqrtsoftplus
+template <typename scalar_t, typename param_t, int NUM_EXPERTS, int TOPK>
+void biased_topk_kernel_impl(
+    float* __restrict__ topk_weights,
+    int32_t* __restrict__ topk_ids,
+    const scalar_t* __restrict__ gating_output,
+    const param_t* __restrict__ bias,
+    int64_t num_tokens,
+    int64_t topk,
+    bool renormalize,
+    int scoring_func,
+    int64_t num_fused_shared_experts,
+    float routed_scaling_factor,
+    bool apply_routed_scaling_factor_on_output) {
+  // actual number of routed experts selected (excluding fused shared experts)
+  const int64_t num_routed_topk = topk - num_fused_shared_experts;
+
+  at::parallel_for(0, num_tokens, 0, [&](int64_t begin, int64_t end) {
+    alignas(64) float scores[NUM_EXPERTS];
+    alignas(64) float scores_biased[NUM_EXPERTS];
+
+    using elem_t = std::pair<float, int32_t>;
+    std::vector<elem_t> queue(NUM_EXPERTS);
+
+    // simple RNG for fused shared expert random ID
+    uint64_t rng_state = begin * 6364136223846793005ULL + 1442695040888963407ULL;
+
+    for (int64_t i = begin; i < end; ++i) {
+      // compute scores
+      if (scoring_func == 0) {
+        sigmoid<scalar_t, NUM_EXPERTS>(scores, gating_output + i * NUM_EXPERTS);
+      } else {
+        sqrtsoftplus<scalar_t, NUM_EXPERTS>(scores, gating_output + i * NUM_EXPERTS);
+      }
+
+      // add bias for selection
+      apply_bias<param_t, NUM_EXPERTS>(scores_biased, scores, bias);
+
+      // build queue and partial sort to find top-k
+      for (int64_t e = 0; e < NUM_EXPERTS; ++e) {
+        queue[e] = {scores_biased[e], static_cast<int32_t>(e)};
+      }
+
+      bool need_sorted = num_fused_shared_experts > 0;
+      if (need_sorted) {
+        std::partial_sort(
+            queue.begin(), queue.begin() + topk, queue.end(), [](const elem_t& x, const elem_t& y) -> bool {
+              return x.first > y.first;
+            });
+      } else {
+        std::partial_sort(
+            queue.begin(), queue.begin() + topk, queue.end(), [](const elem_t& x, const elem_t& y) -> bool {
+              return x.first > y.first;
+            });
+      }
+
+      // gather original scores (without bias) as weights
+      for (int64_t j = 0; j < topk; ++j) {
+        int32_t idx = queue[j].second;
+        topk_ids[i * topk + j] = idx;
+        topk_weights[i * topk + j] = scores[idx];
+      }
+
+      // handle fused shared experts
+      if (num_fused_shared_experts > 0) {
+        // replace last slot with random shared expert ID
+        rng_state = rng_state * 6364136223846793005ULL + 1442695040888963407ULL;
+        int32_t shared_id =
+            NUM_EXPERTS + static_cast<int32_t>((rng_state >> 33) % static_cast<uint64_t>(num_fused_shared_experts));
+        topk_ids[i * topk + topk - 1] = shared_id;
+
+        // shared expert weight = sum of routed weights / scaling_factor
+        if (routed_scaling_factor != 0.0f) {
+          float routed_sum = 0.f;
+          for (int64_t j = 0; j < topk - 1; ++j) {
+            routed_sum += topk_weights[i * topk + j];
+          }
+          topk_weights[i * topk + topk - 1] = routed_sum / routed_scaling_factor;
+        }
+      }
+
+      // renormalize
+      if (renormalize) {
+        float sum = 0.f;
+        int64_t norm_end = (num_fused_shared_experts == 0) ? topk : topk - 1;
+        for (int64_t j = 0; j < norm_end; ++j) {
+          sum += topk_weights[i * topk + j];
+        }
+        float scale = 1.f / sum;
+        if (apply_routed_scaling_factor_on_output) {
+          scale *= routed_scaling_factor;
+        }
+        for (int64_t j = 0; j < norm_end; ++j) {
+          topk_weights[i * topk + j] *= scale;
+        }
+        // also scale the shared expert weight if present
+        if (num_fused_shared_experts > 0) {
+          topk_weights[i * topk + topk - 1] *= scale;
+        }
+      }
+    }
+  });
+}
+
+// hash_topk: expert IDs come from a precomputed lookup table tid2eid[input_ids]
+// scoring_func: 0 = softmax, 1 = sigmoid, 2 = sqrtsoftplus
+template <typename scalar_t, int NUM_EXPERTS, int TOPK>
+void hash_topk_kernel_impl(
+    float* __restrict__ topk_weights,
+    int32_t* __restrict__ topk_ids,
+    const scalar_t* __restrict__ gating_output,
+    const int32_t* __restrict__ tid2eid,  // [num_tokens, routed_topk]
+    int64_t num_tokens,
+    int scoring_func,
+    int64_t num_fused_shared_experts,
+    int64_t num_experts,
+    float routed_scaling_factor,
+    int64_t topk) {
+  const int64_t routed_topk = topk - num_fused_shared_experts;
+  const bool need_renormalize = (scoring_func != 0);  // renormalize for non-softmax
+
+  at::parallel_for(0, num_tokens, 0, [&](int64_t begin, int64_t end) {
+    alignas(64) float scores[NUM_EXPERTS];
+
+    // simple RNG for fused shared expert random ID
+    uint64_t rng_state = begin * 6364136223846793005ULL + 1442695040888963407ULL;
+
+    for (int64_t i = begin; i < end; ++i) {
+      // compute scores over all experts
+      if (scoring_func == 0) {
+        softmax<scalar_t, NUM_EXPERTS>(scores, gating_output + i * NUM_EXPERTS);
+      } else if (scoring_func == 1) {
+        sigmoid<scalar_t, NUM_EXPERTS>(scores, gating_output + i * NUM_EXPERTS);
+      } else {
+        sqrtsoftplus<scalar_t, NUM_EXPERTS>(scores, gating_output + i * NUM_EXPERTS);
+      }
+
+      // gather expert IDs from lookup table
+      const int32_t* eid_row = tid2eid + i * routed_topk;
+      for (int64_t j = 0; j < routed_topk; ++j) {
+        int32_t eid = eid_row[j];
+        topk_ids[i * topk + j] = eid;
+        topk_weights[i * topk + j] = scores[eid];
+      }
+
+      // renormalize routed weights (for non-softmax scoring)
+      if (need_renormalize) {
+        float sum = 0.f;
+        for (int64_t j = 0; j < routed_topk; ++j) {
+          sum += topk_weights[i * topk + j];
+        }
+        if (sum > 0.f) {
+          float scale = 1.f / sum;
+          for (int64_t j = 0; j < routed_topk; ++j) {
+            topk_weights[i * topk + j] *= scale;
+          }
+        }
+      }
+
+      // handle fused shared expert
+      if (num_fused_shared_experts > 0) {
+        // random shared expert ID in [num_experts, num_experts + num_fused_shared_experts)
+        rng_state = rng_state * 6364136223846793005ULL + 1442695040888963407ULL;
+        int32_t shared_id =
+            num_experts + static_cast<int32_t>((rng_state >> 33) % static_cast<uint64_t>(num_fused_shared_experts));
+        topk_ids[i * topk + topk - 1] = shared_id;
+
+        // shared expert weight = sum of routed weights / scaling_factor
+        float routed_sum = 0.f;
+        for (int64_t j = 0; j < routed_topk; ++j) {
+          routed_sum += topk_weights[i * topk + j];
+        }
+        topk_weights[i * topk + topk - 1] = routed_sum / routed_scaling_factor;
+      }
+    }
+  });
+}
+
+#define LAUNCH_HASH_TOPK_KERNEL(NE, NTOPK)    \
+  hash_topk_kernel_impl<scalar_t, NE, NTOPK>( \
+      topk_weights.data_ptr<float>(),         \
+      topk_ids.data_ptr<int32_t>(),           \
+      gating_output.data_ptr<scalar_t>(),     \
+      tid2eid_flat.data_ptr<int32_t>(),       \
+      num_tokens,                             \
+      scoring_func_id,                        \
+      num_fused_shared_experts,               \
+      num_experts,                            \
+      routed_scaling_factor_value,            \
+      topk);
+
+#define LAUNCH_BIASED_TOPK_KERNEL(NE, NTOPK)             \
+  biased_topk_kernel_impl<scalar_t, param_t, NE, NTOPK>( \
+      topk_weights.data_ptr<float>(),                    \
+      topk_ids.data_ptr<int32_t>(),                      \
+      gating_output.data_ptr<scalar_t>(),                \
+      correction_bias.data_ptr<param_t>(),               \
+      num_tokens,                                        \
+      topk,                                              \
+      renormalize,                                       \
+      scoring_func_id,                                   \
+      num_fused_shared_experts,                          \
+      routed_scaling_factor_value,                       \
+      apply_routed_scaling_factor_on_output);
+
 #define LAUNCH_GROUPED_TOPK_KERNEL(NE)    \
   grouped_topk_kernel_impl<scalar_t, NE>( \
       topk_weights.data_ptr<float>(),     \
@@ -446,6 +739,211 @@ void biased_grouped_topk_kernel_impl(
       renormalize);
 
 }  // anonymous namespace
+
+// biased topk for DeepSeek V4 (flat, non-grouped)
+std::tuple<at::Tensor, at::Tensor> biased_topk_cpu(
+    at::Tensor& hidden_states,
+    at::Tensor& gating_output,
+    at::Tensor& correction_bias,
+    int64_t topk,
+    bool renormalize,
+    std::string scoring_func,
+    int64_t num_fused_shared_experts,
+    std::optional<double> routed_scaling_factor,
+    bool apply_routed_scaling_factor_on_output) {
+
+  CHECK_INPUT(gating_output);
+  CHECK_INPUT(correction_bias);
+
+  const auto st = gating_output.scalar_type();
+  int64_t num_tokens = hidden_states.size(0);
+  int64_t num_experts = gating_output.size(1);
+  TORCH_CHECK(gating_output.size(0) == num_tokens, "Number of tokens mismatch");
+  TORCH_CHECK(correction_bias.numel() == num_experts, "Bias shape mismatch");
+
+  int scoring_func_id = 0;
+  if (scoring_func == "sigmoid") {
+    scoring_func_id = 0;
+  } else if (scoring_func == "sqrtsoftplus") {
+    scoring_func_id = 1;
+  } else {
+    TORCH_CHECK(false, "Unsupported scoring_func: ", scoring_func);
+  }
+
+  float routed_scaling_factor_value = routed_scaling_factor.has_value() ? routed_scaling_factor.value() : 0.0f;
+
+  at::Tensor topk_weights = at::empty({num_tokens, topk}, hidden_states.options().dtype(at::kFloat));
+  at::Tensor topk_ids = at::empty({num_tokens, topk}, hidden_states.options().dtype(at::kInt));
+
+  // The actual routed topk (excluding fused shared experts)
+  int64_t routed_topk = topk - num_fused_shared_experts;
+
+  CPU_DISPATCH_FLOATING_TYPES_EXT(st, correction_bias.scalar_type(), "biased_topk_kernel", [&] {
+    // dispatch on num_experts and routed_topk
+    // For DeepSeek V4: typically 256 experts, topk=8 or topk=9 (with 1 fused shared expert)
+    switch (num_experts) {
+      case 64:
+        switch (routed_topk) {
+          case 6:
+            LAUNCH_BIASED_TOPK_KERNEL(64, 6);
+            break;
+          case 8:
+            LAUNCH_BIASED_TOPK_KERNEL(64, 8);
+            break;
+          default:
+            TORCH_CHECK(false, "Unexpected topk: ", topk, " for num_experts=64");
+        }
+        break;
+      case 128:
+        switch (routed_topk) {
+          case 6:
+            LAUNCH_BIASED_TOPK_KERNEL(128, 6);
+            break;
+          case 8:
+            LAUNCH_BIASED_TOPK_KERNEL(128, 8);
+            break;
+          default:
+            TORCH_CHECK(false, "Unexpected topk: ", topk, " for num_experts=128");
+        }
+        break;
+      case 256:
+        switch (routed_topk) {
+          case 6:
+            LAUNCH_BIASED_TOPK_KERNEL(256, 6);
+            break;
+          case 8:
+            LAUNCH_BIASED_TOPK_KERNEL(256, 8);
+            break;
+          case 9:
+            LAUNCH_BIASED_TOPK_KERNEL(256, 9);
+            break;
+          default:
+            TORCH_CHECK(false, "Unexpected topk: ", topk, " for num_experts=256");
+        }
+        break;
+      case 384:
+        switch (routed_topk) {
+          case 8:
+            LAUNCH_BIASED_TOPK_KERNEL(384, 8);
+            break;
+          default:
+            TORCH_CHECK(false, "Unexpected topk: ", topk, " for num_experts=384");
+        }
+        break;
+      default:
+        TORCH_CHECK(false, "Unexpected num_experts: ", num_experts);
+    }
+  });
+  return std::make_tuple(topk_weights, topk_ids);
+}
+
+// hash topk for DeepSeek V4 (expert IDs from precomputed lookup table)
+std::tuple<at::Tensor, at::Tensor> hash_topk_cpu(
+    at::Tensor& gating_output,
+    at::Tensor& tid2eid,
+    int64_t topk,
+    std::string scoring_func,
+    int64_t num_fused_shared_experts,
+    int64_t num_experts,
+    double routed_scaling_factor) {
+  CHECK_INPUT(gating_output);
+  CHECK_INPUT(tid2eid);
+
+  const auto st = gating_output.scalar_type();
+  int64_t num_tokens = gating_output.size(0);
+  int64_t num_experts_gating = gating_output.size(1);
+  int64_t routed_topk = topk - num_fused_shared_experts;
+
+  TORCH_CHECK(tid2eid.size(0) == num_tokens, "tid2eid row count must match num_tokens");
+  TORCH_CHECK(tid2eid.size(1) == routed_topk, "tid2eid column count must match routed_topk");
+  TORCH_CHECK(tid2eid.scalar_type() == at::kInt, "tid2eid must be int32");
+  TORCH_CHECK(num_experts_gating == num_experts, "num_experts mismatch");
+
+  int scoring_func_id = 0;
+  if (scoring_func == "softmax") {
+    scoring_func_id = 0;
+  } else if (scoring_func == "sigmoid") {
+    scoring_func_id = 1;
+  } else if (scoring_func == "sqrtsoftplus") {
+    scoring_func_id = 2;
+  } else {
+    TORCH_CHECK(false, "Unsupported scoring_func: ", scoring_func);
+  }
+
+  float routed_scaling_factor_value = static_cast<float>(routed_scaling_factor);
+
+  at::Tensor topk_weights = at::empty({num_tokens, topk}, gating_output.options().dtype(at::kFloat));
+  at::Tensor topk_ids = at::empty({num_tokens, topk}, gating_output.options().dtype(at::kInt));
+
+  // tid2eid is [num_tokens, routed_topk], already indexed by input_ids in Python
+  at::Tensor tid2eid_flat = tid2eid.contiguous();
+
+  // Dispatch for bf16, fp16, and float32
+  // Note: cannot use AT_DISPATCH_FLOATING_TYPES_AND2 since it includes double which lacks convert_to_float
+  auto dispatch_fn = [&]<typename scalar_t>() {
+    switch (num_experts) {
+      case 64:
+        switch (routed_topk) {
+          case 6:
+            LAUNCH_HASH_TOPK_KERNEL(64, 6);
+            break;
+          case 7:
+            LAUNCH_HASH_TOPK_KERNEL(64, 7);
+            break;
+          case 8:
+            LAUNCH_HASH_TOPK_KERNEL(64, 8);
+            break;
+          default:
+            TORCH_CHECK(false, "Unexpected routed_topk: ", routed_topk, " for num_experts=64");
+        }
+        break;
+      case 128:
+        switch (routed_topk) {
+          case 6:
+            LAUNCH_HASH_TOPK_KERNEL(128, 6);
+            break;
+          case 7:
+            LAUNCH_HASH_TOPK_KERNEL(128, 7);
+            break;
+          case 8:
+            LAUNCH_HASH_TOPK_KERNEL(128, 8);
+            break;
+          default:
+            TORCH_CHECK(false, "Unexpected routed_topk: ", routed_topk, " for num_experts=128");
+        }
+        break;
+      case 256:
+        switch (routed_topk) {
+          case 6:
+            LAUNCH_HASH_TOPK_KERNEL(256, 6);
+            break;
+          case 7:
+            LAUNCH_HASH_TOPK_KERNEL(256, 7);
+            break;
+          case 8:
+            LAUNCH_HASH_TOPK_KERNEL(256, 8);
+            break;
+          default:
+            TORCH_CHECK(false, "Unexpected routed_topk: ", routed_topk, " for num_experts=256");
+        }
+        break;
+      default:
+        TORCH_CHECK(false, "Unexpected num_experts: ", num_experts);
+    }
+  };
+
+  if (st == at::ScalarType::BFloat16) {
+    dispatch_fn.template operator()<at::BFloat16>();
+  } else if (st == at::ScalarType::Half) {
+    dispatch_fn.template operator()<at::Half>();
+  } else if (st == at::ScalarType::Float) {
+    dispatch_fn.template operator()<float>();
+  } else {
+    TORCH_CHECK(false, "Unsupported dtype for hash_topk_cpu: ", st);
+  }
+
+  return std::make_tuple(topk_weights, topk_ids);
+}
 
 std::tuple<at::Tensor, at::Tensor>
 topk_sigmoid_cpu(at::Tensor& hidden_states, at::Tensor& gating_output, int64_t topk, bool renormalize) {

--- a/sgl-kernel/csrc/cpu/torch_extension_cpu.cpp
+++ b/sgl-kernel/csrc/cpu/torch_extension_cpu.cpp
@@ -225,6 +225,10 @@ at::Tensor fused_experts_cpu(
     const std::optional<at::Tensor>& w1_zero,
     const std::optional<at::Tensor>& w2_zero,
     const std::optional<std::vector<int64_t>> block_size,
+    const std::optional<at::Tensor>& w1_bias,
+    const std::optional<at::Tensor>& w2_bias,
+    const std::optional<double>& alpha,
+    const std::optional<double>& limit,
     bool is_vnni);
 
 #if !defined(SGLANG_CPU_ARM64_SKIP_X86_ONLY_OPS)
@@ -550,7 +554,8 @@ TORCH_LIBRARY_FRAGMENT(sgl_kernel, m) {
   m.def(
       "fused_experts_cpu(Tensor hidden_states, Tensor w1, Tensor w2, Tensor topk_weights, Tensor topk_ids, bool "
       "inplace, int moe_comp_method, Tensor? w1_scale, Tensor? w2_scale, "
-      "Tensor? w1_zero, Tensor? w2_zero, int[]? block_size, bool is_vnni) -> Tensor");
+      "Tensor? w1_zero, Tensor? w2_zero, int[]? block_size, Tensor? w1_bias, Tensor? w2_bias, float? alpha, float? "
+      "limit, bool is_vnni) -> Tensor");
   m.impl("fused_experts_cpu", torch::kCPU, &fused_experts_cpu);
 
 #if !defined(SGLANG_CPU_ARM64_SKIP_X86_ONLY_OPS)

--- a/sgl-kernel/csrc/cpu/torch_extension_cpu.cpp
+++ b/sgl-kernel/csrc/cpu/torch_extension_cpu.cpp
@@ -58,6 +58,10 @@ at::Tensor fused_add_layernorm_cpu(
 // topk
 std::tuple<at::Tensor, at::Tensor>
 topk_sigmoid_cpu(at::Tensor& hidden_states, at::Tensor& gating_output, int64_t topk, bool renormalize);
+
+// hadamard transform
+at::Tensor fast_hadamard_transform_cpu(const at::Tensor& x, double scale);
+
 std::tuple<at::Tensor, at::Tensor>
 topk_softmax_cpu(at::Tensor& hidden_states, at::Tensor& gating_output, int64_t topk, bool renormalize);
 
@@ -382,6 +386,19 @@ std::tuple<at::Tensor, at::Tensor> multimodal_rotary_embedding_cpu(
 // CPU and memory binding
 std::string init_cpu_threads_env(const std::string& cpu_ids);
 
+// set_k_and_s
+void set_k_and_s_cpu(
+    at::Tensor& buf,
+    at::Tensor& loc,
+    at::Tensor& k_nope,
+    at::Tensor& k_rope,
+    at::Tensor& scale_k_nope,
+    int64_t page_size);
+
+// quant_to_nope_fp8_rope_bf16_pack
+std::tuple<at::Tensor, at::Tensor, at::Tensor>
+quant_to_nope_fp8_rope_bf16_pack_cpu(at::Tensor& k_bf16);
+
 // fused_sigmoid_gating_delta_rule_update
 at::Tensor fused_sigmoid_gating_delta_rule_update_cpu(
     const at::Tensor& A_log,
@@ -670,6 +687,21 @@ TORCH_LIBRARY_FRAGMENT(sgl_kernel, m) {
 
   // CPU and memory binding
   m.def("init_cpu_threads_env(str cpu_ids) -> str");
+
+  // hadamard transform
+  m.def("fast_hadamard_transform_cpu(Tensor x, float scale) -> Tensor");
+  m.impl("fast_hadamard_transform_cpu", torch::kCPU, &fast_hadamard_transform_cpu);
+
+  // set_k_and_s
+  m.def(
+      "set_k_and_s_cpu(Tensor(a!) buf, Tensor loc, Tensor k_nope, Tensor k_rope, "
+      "Tensor scale_k_nope, int page_size) -> ()");
+  m.impl("set_k_and_s_cpu", torch::kCPU, &set_k_and_s_cpu);
+
+  // quant_to_nope_fp8_rope_bf16_pack
+  m.def(
+      "quant_to_nope_fp8_rope_bf16_pack_cpu(Tensor k_bf16) -> (Tensor, Tensor, Tensor)");
+  m.impl("quant_to_nope_fp8_rope_bf16_pack_cpu", torch::kCPU, &quant_to_nope_fp8_rope_bf16_pack_cpu);
 
   // fused_sigmoid_gating_delta_rule_update
   m.def(

--- a/sgl-kernel/csrc/cpu/torch_extension_cpu.cpp
+++ b/sgl-kernel/csrc/cpu/torch_extension_cpu.cpp
@@ -398,6 +398,14 @@ void set_k_and_s_cpu(
     at::Tensor& scale_k_nope,
     int64_t page_size);
 
+// set_s
+void set_s_cpu(
+    at::Tensor& buf,
+    at::Tensor& loc,
+    at::Tensor& index_k_scale,
+    int64_t page_size,
+    int64_t index_head_dim);
+
 // quant_to_nope_fp8_rope_bf16_pack
 std::tuple<at::Tensor, at::Tensor, at::Tensor>
 quant_to_nope_fp8_rope_bf16_pack_cpu(at::Tensor& k_bf16);
@@ -720,6 +728,12 @@ TORCH_LIBRARY_FRAGMENT(sgl_kernel, m) {
       "set_k_and_s_cpu(Tensor(a!) buf, Tensor loc, Tensor k_nope, Tensor k_rope, "
       "Tensor scale_k_nope, int page_size) -> ()");
   m.impl("set_k_and_s_cpu", torch::kCPU, &set_k_and_s_cpu);
+
+  // set_s
+  m.def(
+      "set_s_cpu(Tensor(a!) buf, Tensor loc, Tensor index_k_scale, "
+      "int page_size, int index_head_dim) -> ()");
+  m.impl("set_s_cpu", torch::kCPU, &set_s_cpu);
 
   // quant_to_nope_fp8_rope_bf16_pack
   m.def(

--- a/sgl-kernel/csrc/cpu/torch_extension_cpu.cpp
+++ b/sgl-kernel/csrc/cpu/torch_extension_cpu.cpp
@@ -474,6 +474,24 @@ std::tuple<at::Tensor, at::Tensor> image_preprocess_cpu(
     bool disable_grouping,
     at::ScalarType out_dtype);
 
+// compressor
+at::Tensor compress_decode_cpu(
+    at::Tensor& pool_kv,
+    at::Tensor& pool_score,
+    at::Tensor& kv,
+    at::Tensor& score,
+    at::Tensor& seq_lens,
+    at::Tensor& req_pool_indices,
+    at::Tensor& ape,
+    at::Tensor& norm_weight,
+    at::Tensor& freqs_cis,
+    int64_t ratio,
+    int64_t head_dim,
+    int64_t rope_head_dim,
+    bool overlap,
+    bool rotate,
+    double norm_eps);
+
 // scheduler: paged allocation
 void alloc_extend_kernel_cpu(
     at::Tensor& pre_lens,
@@ -782,6 +800,13 @@ TORCH_LIBRARY_FRAGMENT(sgl_kernel, m) {
       "image_std, int patch_size, int temporal_patch_size, int merge_size, bool disable_grouping, ScalarType "
       "out_dtype) -> (Tensor, Tensor)");
   m.impl("image_preprocess_cpu", torch::kCPU, &image_preprocess_cpu);
+
+  // compressor
+  m.def(
+      "compress_decode_cpu(Tensor(a!) pool_kv, Tensor(b!) pool_score, Tensor kv, Tensor score, "
+      "Tensor seq_lens, Tensor req_pool_indices, Tensor ape, Tensor norm_weight, Tensor freqs_cis, "
+      "int ratio, int head_dim, int rope_head_dim, bool overlap, bool rotate, float norm_eps) -> Tensor");
+  m.impl("compress_decode_cpu", torch::kCPU, &compress_decode_cpu);
 
   // scheduler: paged allocation
   m.def(

--- a/sgl-kernel/csrc/cpu/torch_extension_cpu.cpp
+++ b/sgl-kernel/csrc/cpu/torch_extension_cpu.cpp
@@ -84,6 +84,26 @@ std::tuple<at::Tensor, at::Tensor> biased_grouped_topk_cpu(
     std::optional<double> routed_scaling_factor,
     std::optional<at::Tensor> num_token_non_padded);
 
+std::tuple<at::Tensor, at::Tensor> biased_topk_cpu(
+    at::Tensor& hidden_states,
+    at::Tensor& gating_output,
+    at::Tensor& correction_bias,
+    int64_t topk,
+    bool renormalize,
+    std::string scoring_func,
+    int64_t num_fused_shared_experts,
+    std::optional<double> routed_scaling_factor,
+    bool apply_routed_scaling_factor_on_output);
+
+std::tuple<at::Tensor, at::Tensor> hash_topk_cpu(
+    at::Tensor& gating_output,
+    at::Tensor& tid2eid,
+    int64_t topk,
+    std::string scoring_func,
+    int64_t num_fused_shared_experts,
+    int64_t num_experts,
+    double routed_scaling_factor);
+
 // attention
 void decode_attention_cpu(
     at::Tensor& query,
@@ -465,6 +485,19 @@ TORCH_LIBRARY_FRAGMENT(sgl_kernel, m) {
       "Tensor? num_token_non_padded) -> (Tensor, Tensor)");
   m.impl("biased_grouped_topk_cpu", torch::kCPU, &biased_grouped_topk_cpu);
 
+  // biased topk (flat, non-grouped)
+  m.def(
+      "biased_topk_cpu(Tensor hidden_states, Tensor gating_output, Tensor correction_bias, int topk, bool "
+      "renormalize, str scoring_func, int num_fused_shared_experts, float? routed_scaling_factor, "
+      "bool apply_routed_scaling_factor_on_output) -> (Tensor, Tensor)");
+  m.impl("biased_topk_cpu", torch::kCPU, &biased_topk_cpu);
+
+  // hash topk (expert IDs from lookup table)
+  m.def(
+      "hash_topk_cpu(Tensor gating_output, Tensor tid2eid, int topk, str scoring_func, "
+      "int num_fused_shared_experts, int num_experts, float routed_scaling_factor) -> (Tensor, Tensor)");
+  m.impl("hash_topk_cpu", torch::kCPU, &hash_topk_cpu);
+
   // decode
   m.def(
       "decode_attention_cpu(Tensor query, Tensor k_cache, Tensor v_cahce, Tensor(a!) output, Tensor key, Tensor value, "
@@ -580,7 +613,8 @@ TORCH_LIBRARY_FRAGMENT(sgl_kernel, m) {
   // shared expert
   m.def(
       "shared_expert_cpu(Tensor hidden_states, Tensor w1, Tensor w2, Tensor? fused_experts_out, float? "
-      "routed_scaling_factor, bool inplace, bool use_int8_w8a8, bool use_fp8_w8a16, bool use_mxfp4, Tensor? w1_scale, Tensor? "
+      "routed_scaling_factor, bool inplace, bool use_int8_w8a8, bool use_fp8_w8a16, bool use_mxfp4, Tensor? w1_scale, "
+      "Tensor? "
       "w2_scale, int[]? block_size, bool is_vnni) -> Tensor");
   m.impl("shared_expert_cpu", torch::kCPU, &shared_expert_cpu);
 

--- a/sgl-kernel/csrc/cpu/torch_extension_cpu.cpp
+++ b/sgl-kernel/csrc/cpu/torch_extension_cpu.cpp
@@ -218,7 +218,12 @@ std::tuple<at::Tensor, at::Tensor, at::Tensor> convert_weight_packed_scale_zp(
 
 // gemm
 at::Tensor
-weight_packed_linear(at::Tensor& mat1, at::Tensor& mat2, const std::optional<at::Tensor>& bias, bool is_vnni);
+weight_packed_linear(
+    at::Tensor& mat1,
+    at::Tensor& mat2,
+    const std::optional<at::Tensor>& bias,
+    bool is_vnni,
+    std::optional<at::ScalarType> out_dtype = c10::nullopt);
 
 // gemm fusion
 at::Tensor fused_linear_sigmoid_mul(
@@ -574,7 +579,7 @@ TORCH_LIBRARY_FRAGMENT(sgl_kernel, m) {
 #endif
 
   // gemm
-  m.def("weight_packed_linear(Tensor mat1, Tensor mat2, Tensor? bias, bool is_vnni) -> Tensor");
+  m.def("weight_packed_linear(Tensor mat1, Tensor mat2, Tensor? bias, bool is_vnni, ScalarType? out_dtype=None) -> Tensor");
   m.impl("weight_packed_linear", torch::kCPU, &weight_packed_linear);
 
   // gemm fusion

--- a/sgl-kernel/csrc/cpu/torch_extension_cpu.cpp
+++ b/sgl-kernel/csrc/cpu/torch_extension_cpu.cpp
@@ -398,6 +398,14 @@ void set_k_and_s_cpu(
     at::Tensor& scale_k_nope,
     int64_t page_size);
 
+// set_k
+void set_k_cpu(
+    at::Tensor& buf,
+    at::Tensor& loc,
+    at::Tensor& index_k,
+    int64_t page_size,
+    int64_t index_head_dim);
+
 // set_s
 void set_s_cpu(
     at::Tensor& buf,
@@ -728,6 +736,12 @@ TORCH_LIBRARY_FRAGMENT(sgl_kernel, m) {
       "set_k_and_s_cpu(Tensor(a!) buf, Tensor loc, Tensor k_nope, Tensor k_rope, "
       "Tensor scale_k_nope, int page_size) -> ()");
   m.impl("set_k_and_s_cpu", torch::kCPU, &set_k_and_s_cpu);
+
+  // set_k
+  m.def(
+      "set_k_cpu(Tensor(a!) buf, Tensor loc, Tensor index_k, "
+      "int page_size, int index_head_dim) -> ()");
+  m.impl("set_k_cpu", torch::kCPU, &set_k_cpu);
 
   // set_s
   m.def(

--- a/sgl-kernel/csrc/cpu/torch_extension_cpu.cpp
+++ b/sgl-kernel/csrc/cpu/torch_extension_cpu.cpp
@@ -173,6 +173,9 @@ at::Tensor convert_scale_packed(at::Tensor& scale);
 
 // quant
 std::tuple<at::Tensor, at::Tensor> per_token_quant_int8_cpu(at::Tensor& A);
+std::tuple<at::Tensor, at::Tensor> act_quant_cpu(
+    at::Tensor& x, int64_t block_size, const std::optional<std::string>& scale_fmt);
+at::Tensor fused_scale_cpu(at::Tensor& weight, double out_scale, at::Tensor& q_scale);
 
 // igemm
 at::Tensor int8_scaled_mm_cpu(
@@ -576,6 +579,10 @@ TORCH_LIBRARY_FRAGMENT(sgl_kernel, m) {
   // quant
   m.def("per_token_quant_int8_cpu(Tensor A) -> (Tensor, Tensor)");
   m.impl("per_token_quant_int8_cpu", torch::kCPU, &per_token_quant_int8_cpu);
+  m.def("act_quant_cpu(Tensor x, int block_size=128, str? scale_fmt=None) -> (Tensor, Tensor)");
+  m.impl("act_quant_cpu", torch::kCPU, &act_quant_cpu);
+  m.def("fused_scale_cpu(Tensor weight, float out_scale, Tensor q_scale) -> Tensor");
+  m.impl("fused_scale_cpu", torch::kCPU, &fused_scale_cpu);
 
   // igemm
   m.def(

--- a/sgl-kernel/csrc/cpu/torch_extension_cpu.cpp
+++ b/sgl-kernel/csrc/cpu/torch_extension_cpu.cpp
@@ -265,6 +265,8 @@ at::Tensor shared_expert_cpu(
     const std::optional<at::Tensor>& w1_scale,
     const std::optional<at::Tensor>& w2_scale,
     const std::optional<std::vector<int64_t>> block_size,
+    const std::optional<double>& alpha,
+    const std::optional<double>& limit,
     bool is_vnni);
 
 // weight absorption
@@ -615,7 +617,7 @@ TORCH_LIBRARY_FRAGMENT(sgl_kernel, m) {
       "shared_expert_cpu(Tensor hidden_states, Tensor w1, Tensor w2, Tensor? fused_experts_out, float? "
       "routed_scaling_factor, bool inplace, bool use_int8_w8a8, bool use_fp8_w8a16, bool use_mxfp4, Tensor? w1_scale, "
       "Tensor? "
-      "w2_scale, int[]? block_size, bool is_vnni) -> Tensor");
+      "w2_scale, int[]? block_size, float? alpha, float? limit, bool is_vnni) -> Tensor");
   m.impl("shared_expert_cpu", torch::kCPU, &shared_expert_cpu);
 
   // causal conv1d

--- a/sgl-kernel/csrc/cpu/torch_extension_cpu.cpp
+++ b/sgl-kernel/csrc/cpu/torch_extension_cpu.cpp
@@ -241,6 +241,7 @@ at::Tensor shared_expert_cpu(
     bool inplace,
     bool use_int8_w8a8,
     bool use_fp8_w8a16,
+    bool use_mxfp4,
     const std::optional<at::Tensor>& w1_scale,
     const std::optional<at::Tensor>& w2_scale,
     const std::optional<std::vector<int64_t>> block_size,
@@ -579,7 +580,7 @@ TORCH_LIBRARY_FRAGMENT(sgl_kernel, m) {
   // shared expert
   m.def(
       "shared_expert_cpu(Tensor hidden_states, Tensor w1, Tensor w2, Tensor? fused_experts_out, float? "
-      "routed_scaling_factor, bool inplace, bool use_int8_w8a8, bool use_fp8_w8a16, Tensor? w1_scale, Tensor? "
+      "routed_scaling_factor, bool inplace, bool use_int8_w8a8, bool use_fp8_w8a16, bool use_mxfp4, Tensor? w1_scale, Tensor? "
       "w2_scale, int[]? block_size, bool is_vnni) -> Tensor");
   m.impl("shared_expert_cpu", torch::kCPU, &shared_expert_cpu);
 

--- a/sgl-kernel/csrc/cpu/torch_extension_cpu.cpp
+++ b/sgl-kernel/csrc/cpu/torch_extension_cpu.cpp
@@ -455,6 +455,22 @@ std::tuple<at::Tensor, at::Tensor> image_preprocess_cpu(
     bool disable_grouping,
     at::ScalarType out_dtype);
 
+// scheduler: paged allocation
+void alloc_extend_kernel_cpu(
+    at::Tensor& pre_lens,
+    at::Tensor& seq_lens,
+    at::Tensor& last_loc,
+    at::Tensor& free_pages,
+    at::Tensor& out_indices,
+    int64_t page_size);
+
+void alloc_decode_kernel_cpu(
+    at::Tensor& seq_lens,
+    at::Tensor& last_loc,
+    at::Tensor& free_pages,
+    at::Tensor& out_indices,
+    int64_t page_size);
+
 // [NOTE] When registering kernels, we should accurately describe the in-place information.
 // Taking fused_add_rmsnorm_cpu as an example, add `Tensor(a!)` modifier to all tensors that
 // will be modified in-place to avoid incorrect fusing and execution order on graph mode.
@@ -731,6 +747,17 @@ TORCH_LIBRARY_FRAGMENT(sgl_kernel, m) {
       "image_std, int patch_size, int temporal_patch_size, int merge_size, bool disable_grouping, ScalarType "
       "out_dtype) -> (Tensor, Tensor)");
   m.impl("image_preprocess_cpu", torch::kCPU, &image_preprocess_cpu);
+
+  // scheduler: paged allocation
+  m.def(
+      "alloc_extend_kernel_cpu(Tensor pre_lens, Tensor seq_lens, Tensor last_loc, "
+      "Tensor free_pages, Tensor(a!) out_indices, int page_size) -> ()");
+  m.impl("alloc_extend_kernel_cpu", torch::kCPU, &alloc_extend_kernel_cpu);
+
+  m.def(
+      "alloc_decode_kernel_cpu(Tensor seq_lens, Tensor last_loc, "
+      "Tensor free_pages, Tensor(a!) out_indices, int page_size) -> ()");
+  m.impl("alloc_decode_kernel_cpu", torch::kCPU, &alloc_decode_kernel_cpu);
 }
 
 TORCH_LIBRARY_IMPL(sgl_kernel, CatchAll, m) {

--- a/sgl-kernel/csrc/cpu/vec.h
+++ b/sgl-kernel/csrc/cpu/vec.h
@@ -6,6 +6,7 @@
 
 #include <ATen/cpu/vec/functional.h>
 #include <ATen/cpu/vec/vec.h>
+#include <immintrin.h>
 
 namespace {
 
@@ -14,6 +15,15 @@ using namespace at::vec;
 template <typename scalar_t, typename std::enable_if_t<is_reduced_floating_point_v<scalar_t>, int> = 0>
 inline Vectorized<scalar_t> convert_from_float_ext(const Vectorized<float>& a, const Vectorized<float>& b) {
   return at::vec::convert_from_float<scalar_t>(a, b);
+}
+
+template <typename scalar_t>
+inline void convert_from_float_and_store(scalar_t* out, const Vectorized<float>& a) {
+  float out_buffer[at::vec::Vectorized<float>::size()];
+  a.store(out_buffer);
+  for (int i = 0; i < 16; i++) {
+    out[i] = (scalar_t)out_buffer[i];
+  }
 }
 
 // allow f16, bf16
@@ -43,6 +53,11 @@ template <>
 inline Vectorized<at::BFloat16>
 convert_from_float_ext<at::BFloat16>(const Vectorized<float>& a, const Vectorized<float>& b) {
   return (__m512i)(_mm512_cvtne2ps_pbh(__m512(b), __m512(a)));
+}
+
+template <>
+inline void convert_from_float_and_store<at::BFloat16>(at::BFloat16* out, const Vectorized<float>& a) {
+  _mm256_storeu_si256((__m256i*)out, (__m256i)(_mm512_cvtneps_pbh(__m512(a))));
 }
 
 #define CVT_BF16_TO_FP32(a) _mm512_castsi512_ps(_mm512_slli_epi32(_mm512_cvtepu16_epi32(a), 16))

--- a/test/srt/cpu/test_act_quant_cpu.py
+++ b/test/srt/cpu/test_act_quant_cpu.py
@@ -1,0 +1,119 @@
+import itertools
+import unittest
+
+import torch
+from typing import Optional, Tuple
+from sglang.test.test_utils import CustomTestCase
+
+def act_quant_pytorch(
+    x: torch.Tensor, block_size: int = 128, scale_fmt: Optional[str] = None
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """
+    Quantizes the input tensor `x` using block-wise quantization (PyTorch native).
+    This is a pure PyTorch implementation equivalent to the Triton kernel version.
+    It performs per-block FP8 quantization along the last dimension.
+    Args:
+        x (torch.Tensor): The input tensor to be quantized. Must be contiguous and
+            its last dimension size must be divisible by `block_size`.
+        block_size (int, optional): The size of the blocks used for quantization.
+            Default is 128.
+        scale_fmt (Optional[str], optional): If not None, scales are rounded to
+            powers of 2. Default is None.
+    Returns:
+        Tuple[torch.Tensor, torch.Tensor]: A tuple containing:
+            - The quantized tensor with dtype `torch.float8_e4m3fn`.
+            - A tensor of scaling factors with dtype `torch.float32`.
+    """
+    assert x.is_contiguous(), "Input tensor must be contiguous"
+    assert (
+        x.size(-1) % block_size == 0
+    ), f"Last dimension size must be divisible by block_size (block_size={block_size})"
+
+    # FP8 e4m3fn constants
+    fp8_max = 448.0
+    fp8_min = -448.0
+
+    # Flatten all dims except last
+    orig_shape = x.shape
+    N = x.size(-1)
+    x_flat = x.view(-1, N).float()  # (M, N)
+    M = x_flat.size(0)
+    num_groups = N // block_size
+
+    # Reshape into blocks: (M, num_groups, block_size)
+    x_blocked = x_flat.view(M, num_groups, block_size)
+
+    # Compute per-block absolute max -> (M, num_groups)
+    amax = x_blocked.abs().amax(dim=2)
+
+    # Clamp to avoid division by zero
+    amax = amax.clamp(min=1e-4)
+
+    # Compute scale
+    round_scale = scale_fmt is not None
+    if round_scale:
+        # Round scale to nearest power of 2 (ceiling in log2 space)
+        scale = torch.exp2(torch.ceil(torch.log2(amax / fp8_max)))
+    else:
+        scale = amax / fp8_max
+
+    # Quantize: y = clamp(x / scale, fp8_min, fp8_max)
+    # scale shape: (M, num_groups) -> broadcast to (M, num_groups, block_size)
+    y = x_blocked / scale.unsqueeze(2)
+    y = y.clamp(fp8_min, fp8_max)
+
+    # Reshape output back to original shape and cast to fp8
+    y = y.view(orig_shape).to(torch.float8_e4m3fn)
+
+    # Reshape scale to match expected output shape: (*orig_shape[:-1], num_groups)
+    s = scale.view(*orig_shape[:-1], num_groups)
+
+    return y, s
+
+
+def _assert_fp8_equal(ref: torch.Tensor, out: torch.Tensor) -> None:
+    assert ref.dtype == torch.float8_e4m3fn
+    assert out.dtype == torch.float8_e4m3fn
+    torch.testing.assert_close(ref.view(torch.uint8), out.view(torch.uint8), atol=0, rtol=0)
+
+
+class TestActQuantCPU(CustomTestCase):
+    shapes = [(1, 128), (3, 256), (2, 3, 128), (2, 2, 384)]
+    dtypes = [torch.float32, torch.bfloat16, torch.float16]
+    scale_fmts = [None, "power2"]
+
+    def _run_case(self, shape, dtype, scale_fmt):
+        torch.manual_seed(1234)
+        x = (torch.randn(shape, dtype=torch.float32) * 3.0).to(dtype).contiguous()
+
+        ref_y, ref_scale = act_quant_pytorch(x, block_size=128, scale_fmt=scale_fmt)
+        out_y, out_scale = torch.ops.sgl_kernel.act_quant_cpu(
+            x, 128, scale_fmt
+        )
+
+        _assert_fp8_equal(ref_y, out_y)
+        torch.testing.assert_close(ref_scale, out_scale, atol=0, rtol=0)
+
+    def test_act_quant_cpu(self):
+        for shape, dtype, scale_fmt in itertools.product(
+            self.shapes, self.dtypes, self.scale_fmts
+        ):
+            with self.subTest(shape=shape, dtype=dtype, scale_fmt=scale_fmt):
+                self._run_case(shape, dtype, scale_fmt)
+
+    def test_zeros_use_min_scale(self):
+        x = torch.zeros((2, 128), dtype=torch.bfloat16)
+        ref_y, ref_scale = act_quant_pytorch(x, block_size=128)
+        out_y, out_scale = torch.ops.sgl_kernel.act_quant_cpu(x, 128, None)
+
+        _assert_fp8_equal(ref_y, out_y)
+        torch.testing.assert_close(ref_scale, out_scale, atol=0, rtol=0)
+
+    def test_invalid_block_size(self):
+        x = torch.randn((2, 129), dtype=torch.float32)
+        with self.assertRaisesRegex(RuntimeError, "Last dimension size must be divisible"):
+            torch.ops.sgl_kernel.act_quant_cpu(x, 128, None)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/srt/cpu/test_allocator.py
+++ b/test/srt/cpu/test_allocator.py
@@ -1,0 +1,540 @@
+"""
+Unit tests and benchmarks for alloc_extend_kernel_cpu and alloc_decode_kernel_cpu.
+"""
+
+import time
+import unittest
+
+import torch
+
+from sglang.test.test_utils import CustomTestCase
+
+
+def _ceil_div(a, b):
+    """Integer ceiling division. Works for both Python ints and torch Tensors."""
+    return (a + b - 1) // b
+
+
+def alloc_extend_kernel_pytorch(
+    pre_lens, seq_lens, last_loc, free_pages, out_indices, page_size
+):
+    """Reference PyTorch implementation."""
+    bs = pre_lens.shape[0]
+    extend_lens = seq_lens - pre_lens
+    extend_cumsum = torch.cumsum(extend_lens, dim=0)
+    output_start_locs = extend_cumsum - extend_lens
+
+    num_pages_after = _ceil_div(seq_lens, page_size)
+    num_pages_before = _ceil_div(pre_lens, page_size)
+    num_new_pages = num_pages_after - num_pages_before
+    new_pages_cumsum = torch.cumsum(num_new_pages, dim=0)
+    new_page_start_locs = new_pages_cumsum - num_new_pages
+
+    for i in range(bs):
+        pre_len = pre_lens[i].item()
+        seq_len = seq_lens[i].item()
+        extend_len = seq_len - pre_len
+        if extend_len == 0:
+            continue
+
+        output_start = output_start_locs[i].item()
+        new_page_start = new_page_start_locs[i].item()
+        num_new_pages_self = num_new_pages[i].item()
+        last_loc_i = last_loc[i].item()
+
+        page_boundary = _ceil_div(pre_len, page_size) * page_size
+        num_part1 = min(seq_len, page_boundary) - pre_len
+        if num_part1 > 0:
+            offsets = torch.arange(num_part1, device=out_indices.device)
+            out_indices[output_start : output_start + num_part1] = (
+                last_loc_i + 1 + offsets
+            )
+
+        if pre_len + num_part1 == seq_len:
+            continue
+
+        full_page_end = (seq_len // page_size) * page_size
+        full_page_start = _ceil_div(pre_len, page_size) * page_size
+        num_part2 = full_page_end - full_page_start
+        if num_part2 > 0:
+            offsets = torch.arange(num_part2, device=out_indices.device)
+            page_indices = offsets // page_size
+            in_page_offsets = offsets % page_size
+            pages = free_pages[new_page_start + page_indices]
+            out_indices[
+                output_start + num_part1 : output_start + num_part1 + num_part2
+            ] = (pages * page_size + in_page_offsets)
+
+        if pre_len + num_part1 + num_part2 == seq_len:
+            continue
+
+        num_part3 = seq_len - (seq_len // page_size) * page_size
+        if num_part3 > 0:
+            start_page = free_pages[new_page_start + num_new_pages_self - 1].item()
+            offsets = torch.arange(num_part3, device=out_indices.device)
+            out_indices[
+                output_start
+                + num_part1
+                + num_part2 : output_start
+                + num_part1
+                + num_part2
+                + num_part3
+            ] = (start_page * page_size + offsets)
+
+
+def alloc_decode_kernel_pytorch(seq_lens, last_loc, free_pages, out_indices, page_size):
+    """Reference PyTorch implementation."""
+    pre_lens = seq_lens - 1
+    num_pages_after = _ceil_div(seq_lens, page_size)
+    num_pages_before = _ceil_div(pre_lens, page_size)
+    num_new_pages = num_pages_after - num_pages_before
+
+    new_pages_cumsum = torch.cumsum(num_new_pages, dim=0)
+    new_page_start_locs = new_pages_cumsum - num_new_pages
+
+    no_new_page_mask = num_new_pages == 0
+    out_indices[no_new_page_mask] = last_loc[no_new_page_mask].to(out_indices.dtype) + 1
+
+    new_page_mask = num_new_pages > 0
+    if new_page_mask.any():
+        new_page_offsets = new_page_start_locs[new_page_mask]
+        pages = free_pages[new_page_offsets]
+        out_indices[new_page_mask] = pages.to(out_indices.dtype) * page_size
+
+
+def _gen_extend_test_data(bs, page_size, max_pre_len=128, max_extend_len=64):
+    """Generate consistent test data for alloc_extend_kernel."""
+    pre_lens = torch.randint(0, max_pre_len + 1, (bs,), dtype=torch.int64)
+    extend_lens = torch.randint(1, max_extend_len + 1, (bs,), dtype=torch.int64)
+    seq_lens = pre_lens + extend_lens
+
+    # Compute last_loc: for each request, simulate the physical location of
+    # the last token in the prefix. last_loc must satisfy:
+    #   (last_loc + 1) % page_size == pre_len % page_size
+    # We simulate by placing prefix pages sequentially starting from some base page.
+    last_loc = torch.zeros(bs, dtype=torch.int64)
+    page_counter = 0
+    for i in range(bs):
+        pre_len = pre_lens[i].item()
+        if pre_len == 0:
+            last_loc[i] = 0
+        else:
+            num_pages = (pre_len + page_size - 1) // page_size
+            # last page of prefix
+            last_page = page_counter + num_pages - 1
+            in_page_offset = (pre_len - 1) % page_size
+            last_loc[i] = last_page * page_size + in_page_offset
+            page_counter += num_pages
+
+    # Generate free pages (enough for all requests)
+    total_new_pages = 0
+    for i in range(bs):
+        pages_after = (seq_lens[i].item() + page_size - 1) // page_size
+        pages_before = (pre_lens[i].item() + page_size - 1) // page_size
+        total_new_pages += pages_after - pages_before
+    free_pages = torch.arange(
+        page_counter, page_counter + total_new_pages + 100, dtype=torch.int64
+    )
+
+    extend_num_tokens = extend_lens.sum().item()
+    return pre_lens, seq_lens, last_loc, free_pages, extend_num_tokens
+
+
+def _gen_decode_test_data(bs, page_size, max_seq_len=256):
+    """Generate consistent test data for alloc_decode_kernel."""
+    # seq_lens are the lengths AFTER the decode step (already incremented by 1)
+    seq_lens = torch.randint(2, max_seq_len + 1, (bs,), dtype=torch.int64)
+
+    # last_loc: simulate physical location of the last allocated token
+    last_loc = torch.zeros(bs, dtype=torch.int64)
+    page_counter = 0
+    for i in range(bs):
+        pre_len = seq_lens[i].item() - 1  # length before decode
+        if pre_len == 0:
+            last_loc[i] = 0
+        else:
+            num_pages = (pre_len + page_size - 1) // page_size
+            last_page = page_counter + num_pages - 1
+            in_page_offset = (pre_len - 1) % page_size
+            last_loc[i] = last_page * page_size + in_page_offset
+            page_counter += num_pages
+
+    # Free pages
+    total_new_pages = 0
+    for i in range(bs):
+        pages_after = (seq_lens[i].item() + page_size - 1) // page_size
+        pages_before = ((seq_lens[i].item() - 1) + page_size - 1) // page_size
+        total_new_pages += pages_after - pages_before
+    free_pages = torch.arange(
+        page_counter, page_counter + total_new_pages + 100, dtype=torch.int64
+    )
+
+    return seq_lens, last_loc, free_pages
+
+
+class TestAllocExtendKernel(CustomTestCase):
+    def _run_test(self, bs, page_size, max_pre_len=128, max_extend_len=64):
+        pre_lens, seq_lens, last_loc, free_pages, extend_num_tokens = (
+            _gen_extend_test_data(bs, page_size, max_pre_len, max_extend_len)
+        )
+
+        # Reference
+        out_ref = torch.empty(extend_num_tokens, dtype=torch.int64)
+        alloc_extend_kernel_pytorch(
+            pre_lens, seq_lens, last_loc, free_pages, out_ref, page_size
+        )
+
+        # CPU kernel
+        out_cpu = torch.empty(extend_num_tokens, dtype=torch.int64)
+        torch.ops.sgl_kernel.alloc_extend_kernel_cpu(
+            pre_lens, seq_lens, last_loc, free_pages, out_cpu, page_size
+        )
+
+        torch.testing.assert_close(out_cpu, out_ref)
+
+    def test_basic_page_size_1(self):
+        self._run_test(bs=4, page_size=1)
+
+    def test_basic_page_size_16(self):
+        self._run_test(bs=8, page_size=16)
+
+    def test_basic_page_size_128(self):
+        self._run_test(bs=8, page_size=128)
+
+    def test_single_request(self):
+        self._run_test(bs=1, page_size=16)
+
+    def test_large_batch(self):
+        self._run_test(bs=256, page_size=16, max_pre_len=512, max_extend_len=256)
+
+    def test_all_full_pages(self):
+        """All pre_lens and seq_lens are multiples of page_size."""
+        page_size = 16
+        bs = 4
+        pre_lens = torch.tensor([0, 16, 32, 48], dtype=torch.int64)
+        seq_lens = torch.tensor([16, 32, 64, 64], dtype=torch.int64)
+        extend_lens = seq_lens - pre_lens
+        extend_num_tokens = extend_lens.sum().item()
+
+        last_loc = torch.zeros(bs, dtype=torch.int64)
+        page_counter = 0
+        for i in range(bs):
+            pre_len = pre_lens[i].item()
+            if pre_len == 0:
+                last_loc[i] = 0
+            else:
+                num_pages = pre_len // page_size
+                last_page = page_counter + num_pages - 1
+                last_loc[i] = last_page * page_size + page_size - 1
+                page_counter += num_pages
+        total_new_pages = sum(
+            (seq_lens[i].item() + page_size - 1) // page_size
+            - (pre_lens[i].item() + page_size - 1) // page_size
+            for i in range(bs)
+        )
+        free_pages = torch.arange(
+            page_counter, page_counter + total_new_pages + 10, dtype=torch.int64
+        )
+
+        out_ref = torch.empty(extend_num_tokens, dtype=torch.int64)
+        alloc_extend_kernel_pytorch(
+            pre_lens, seq_lens, last_loc, free_pages, out_ref, page_size
+        )
+        out_cpu = torch.empty(extend_num_tokens, dtype=torch.int64)
+        torch.ops.sgl_kernel.alloc_extend_kernel_cpu(
+            pre_lens, seq_lens, last_loc, free_pages, out_cpu, page_size
+        )
+        torch.testing.assert_close(out_cpu, out_ref)
+
+    def test_zero_extend(self):
+        """Some requests have zero extend length."""
+        page_size = 16
+        bs = 4
+        pre_lens = torch.tensor([10, 20, 30, 40], dtype=torch.int64)
+        seq_lens = torch.tensor([10, 25, 30, 50], dtype=torch.int64)
+        extend_lens = seq_lens - pre_lens
+        extend_num_tokens = extend_lens.sum().item()
+
+        last_loc = torch.zeros(bs, dtype=torch.int64)
+        page_counter = 0
+        for i in range(bs):
+            pre_len = pre_lens[i].item()
+            if pre_len == 0:
+                last_loc[i] = 0
+            else:
+                num_pages = (pre_len + page_size - 1) // page_size
+                last_page = page_counter + num_pages - 1
+                in_page_offset = (pre_len - 1) % page_size
+                last_loc[i] = last_page * page_size + in_page_offset
+                page_counter += num_pages
+
+        total_new_pages = sum(
+            (seq_lens[i].item() + page_size - 1) // page_size
+            - (pre_lens[i].item() + page_size - 1) // page_size
+            for i in range(bs)
+        )
+        free_pages = torch.arange(
+            page_counter, page_counter + total_new_pages + 10, dtype=torch.int64
+        )
+
+        out_ref = torch.empty(extend_num_tokens, dtype=torch.int64)
+        alloc_extend_kernel_pytorch(
+            pre_lens, seq_lens, last_loc, free_pages, out_ref, page_size
+        )
+        out_cpu = torch.empty(extend_num_tokens, dtype=torch.int64)
+        torch.ops.sgl_kernel.alloc_extend_kernel_cpu(
+            pre_lens, seq_lens, last_loc, free_pages, out_cpu, page_size
+        )
+        torch.testing.assert_close(out_cpu, out_ref)
+
+    def _run_test_int32(self, bs, page_size, max_pre_len=128, max_extend_len=64):
+        pre_lens, seq_lens, last_loc, free_pages, extend_num_tokens = (
+            _gen_extend_test_data(bs, page_size, max_pre_len, max_extend_len)
+        )
+        # Convert to int32
+        pre_lens = pre_lens.to(torch.int32)
+        seq_lens = seq_lens.to(torch.int32)
+        last_loc = last_loc.to(torch.int32)
+        free_pages = free_pages.to(torch.int32)
+
+        # Reference (use int64 for reference)
+        out_ref = torch.empty(extend_num_tokens, dtype=torch.int64)
+        alloc_extend_kernel_pytorch(
+            pre_lens.to(torch.int64), seq_lens.to(torch.int64),
+            last_loc.to(torch.int64), free_pages.to(torch.int64),
+            out_ref, page_size
+        )
+
+        # CPU kernel with int32
+        out_cpu = torch.empty(extend_num_tokens, dtype=torch.int32)
+        torch.ops.sgl_kernel.alloc_extend_kernel_cpu(
+            pre_lens, seq_lens, last_loc, free_pages, out_cpu, page_size
+        )
+
+        torch.testing.assert_close(out_cpu.to(torch.int64), out_ref)
+
+    def test_int32_basic(self):
+        self._run_test_int32(bs=8, page_size=16)
+
+    def test_int32_large_batch(self):
+        self._run_test_int32(bs=64, page_size=16)
+
+    def _run_test(self, bs, page_size, max_seq_len=256):
+        seq_lens, last_loc, free_pages = _gen_decode_test_data(
+            bs, page_size, max_seq_len
+        )
+
+        # Reference
+        out_ref = torch.empty(bs, dtype=torch.int64)
+        alloc_decode_kernel_pytorch(seq_lens, last_loc, free_pages, out_ref, page_size)
+
+        # CPU kernel
+        out_cpu = torch.empty(bs, dtype=torch.int64)
+        torch.ops.sgl_kernel.alloc_decode_kernel_cpu(
+            seq_lens, last_loc, free_pages, out_cpu, page_size
+        )
+
+        torch.testing.assert_close(out_cpu, out_ref)
+
+    def test_basic_page_size_1(self):
+        self._run_test(bs=4, page_size=1)
+
+    def test_basic_page_size_16(self):
+        self._run_test(bs=8, page_size=16)
+
+    def test_basic_page_size_128(self):
+        self._run_test(bs=8, page_size=128)
+
+    def test_single_request(self):
+        self._run_test(bs=1, page_size=16)
+
+    def test_large_batch(self):
+        self._run_test(bs=1024, page_size=16)
+
+    def test_all_need_new_page(self):
+        """All requests need a new page (seq_len is at page boundary)."""
+        page_size = 16
+        bs = 4
+        # seq_lens at multiples of page_size + 1 => need new page
+        seq_lens = torch.tensor([17, 33, 49, 65], dtype=torch.int64)
+        last_loc = torch.zeros(bs, dtype=torch.int64)
+        page_counter = 0
+        for i in range(bs):
+            pre_len = seq_lens[i].item() - 1
+            num_pages = (pre_len + page_size - 1) // page_size
+            last_page = page_counter + num_pages - 1
+            in_page_offset = (pre_len - 1) % page_size
+            last_loc[i] = last_page * page_size + in_page_offset
+            page_counter += num_pages
+
+        free_pages = torch.arange(page_counter, page_counter + bs + 10, dtype=torch.int64)
+
+        out_ref = torch.empty(bs, dtype=torch.int64)
+        alloc_decode_kernel_pytorch(seq_lens, last_loc, free_pages, out_ref, page_size)
+        out_cpu = torch.empty(bs, dtype=torch.int64)
+        torch.ops.sgl_kernel.alloc_decode_kernel_cpu(
+            seq_lens, last_loc, free_pages, out_cpu, page_size
+        )
+        torch.testing.assert_close(out_cpu, out_ref)
+
+    def test_none_need_new_page(self):
+        """No requests need a new page."""
+        page_size = 16
+        bs = 4
+        seq_lens = torch.tensor([2, 3, 10, 15], dtype=torch.int64)
+        last_loc = torch.zeros(bs, dtype=torch.int64)
+        page_counter = 0
+        for i in range(bs):
+            pre_len = seq_lens[i].item() - 1
+            if pre_len == 0:
+                last_loc[i] = 0
+            else:
+                num_pages = (pre_len + page_size - 1) // page_size
+                last_page = page_counter + num_pages - 1
+                in_page_offset = (pre_len - 1) % page_size
+                last_loc[i] = last_page * page_size + in_page_offset
+                page_counter += num_pages
+
+        free_pages = torch.arange(page_counter, page_counter + 10, dtype=torch.int64)
+
+        out_ref = torch.empty(bs, dtype=torch.int64)
+        alloc_decode_kernel_pytorch(seq_lens, last_loc, free_pages, out_ref, page_size)
+        out_cpu = torch.empty(bs, dtype=torch.int64)
+        torch.ops.sgl_kernel.alloc_decode_kernel_cpu(
+            seq_lens, last_loc, free_pages, out_cpu, page_size
+        )
+        torch.testing.assert_close(out_cpu, out_ref)
+
+    def _run_test_int32(self, bs, page_size, max_seq_len=256):
+        seq_lens, last_loc, free_pages = _gen_decode_test_data(
+            bs, page_size, max_seq_len
+        )
+        seq_lens = seq_lens.to(torch.int32)
+        last_loc = last_loc.to(torch.int32)
+        free_pages = free_pages.to(torch.int32)
+
+        # Reference
+        out_ref = torch.empty(bs, dtype=torch.int64)
+        alloc_decode_kernel_pytorch(
+            seq_lens.to(torch.int64), last_loc.to(torch.int64),
+            free_pages.to(torch.int64), out_ref, page_size
+        )
+
+        # CPU kernel with int32
+        out_cpu = torch.empty(bs, dtype=torch.int32)
+        torch.ops.sgl_kernel.alloc_decode_kernel_cpu(
+            seq_lens, last_loc, free_pages, out_cpu, page_size
+        )
+
+        torch.testing.assert_close(out_cpu.to(torch.int64), out_ref)
+
+    def test_int32_basic(self):
+        self._run_test_int32(bs=8, page_size=16)
+
+    def test_int32_large_batch(self):
+        self._run_test_int32(bs=256, page_size=16)
+
+
+    @staticmethod
+    def bench_alloc_extend(bs, page_size, max_pre_len=512, max_extend_len=256,
+                           warmup=10, iters=100):
+        pre_lens, seq_lens, last_loc, free_pages, extend_num_tokens = (
+            _gen_extend_test_data(bs, page_size, max_pre_len, max_extend_len)
+        )
+
+        # Benchmark reference (PyTorch)
+        for _ in range(warmup):
+            out = torch.empty(extend_num_tokens, dtype=torch.int64)
+            alloc_extend_kernel_pytorch(
+                pre_lens, seq_lens, last_loc, free_pages, out, page_size
+            )
+        t0 = time.perf_counter()
+        for _ in range(iters):
+            out = torch.empty(extend_num_tokens, dtype=torch.int64)
+            alloc_extend_kernel_pytorch(
+                pre_lens, seq_lens, last_loc, free_pages, out, page_size
+            )
+        ref_time = (time.perf_counter() - t0) / iters * 1e6  # us
+
+        # Benchmark CPU kernel
+        for _ in range(warmup):
+            out = torch.empty(extend_num_tokens, dtype=torch.int64)
+            torch.ops.sgl_kernel.alloc_extend_kernel_cpu(
+                pre_lens, seq_lens, last_loc, free_pages, out, page_size
+            )
+        t0 = time.perf_counter()
+        for _ in range(iters):
+            out = torch.empty(extend_num_tokens, dtype=torch.int64)
+            torch.ops.sgl_kernel.alloc_extend_kernel_cpu(
+                pre_lens, seq_lens, last_loc, free_pages, out, page_size
+            )
+        cpu_time = (time.perf_counter() - t0) / iters * 1e6  # us
+
+        print(
+            f"alloc_extend | bs={bs:4d} page_size={page_size:3d} extend_tokens={extend_num_tokens:6d} | "
+            f"PyTorch: {ref_time:8.1f} us | C++: {cpu_time:8.1f} us | "
+            f"Speedup: {ref_time / cpu_time:5.2f}x"
+        )
+
+    @staticmethod
+    def bench_alloc_decode(bs, page_size, max_seq_len=256, warmup=10, iters=100):
+        seq_lens, last_loc, free_pages = _gen_decode_test_data(
+            bs, page_size, max_seq_len
+        )
+
+        # Benchmark reference (PyTorch)
+        for _ in range(warmup):
+            out = torch.empty(bs, dtype=torch.int64)
+            alloc_decode_kernel_pytorch(
+                seq_lens, last_loc, free_pages, out, page_size
+            )
+        t0 = time.perf_counter()
+        for _ in range(iters):
+            out = torch.empty(bs, dtype=torch.int64)
+            alloc_decode_kernel_pytorch(
+                seq_lens, last_loc, free_pages, out, page_size
+            )
+        ref_time = (time.perf_counter() - t0) / iters * 1e6  # us
+
+        # Benchmark CPU kernel
+        for _ in range(warmup):
+            out = torch.empty(bs, dtype=torch.int64)
+            torch.ops.sgl_kernel.alloc_decode_kernel_cpu(
+                seq_lens, last_loc, free_pages, out, page_size
+            )
+        t0 = time.perf_counter()
+        for _ in range(iters):
+            out = torch.empty(bs, dtype=torch.int64)
+            torch.ops.sgl_kernel.alloc_decode_kernel_cpu(
+                seq_lens, last_loc, free_pages, out, page_size
+            )
+        cpu_time = (time.perf_counter() - t0) / iters * 1e6  # us
+
+        print(
+            f"alloc_decode | bs={bs:4d} page_size={page_size:3d} | "
+            f"PyTorch: {ref_time:8.1f} us | C++: {cpu_time:8.1f} us | "
+            f"Speedup: {ref_time / cpu_time:5.2f}x"
+        )
+
+
+if __name__ == "__main__":
+    import sys
+
+    if "--bench" in sys.argv:
+        sys.argv.remove("--bench")
+        print("=" * 80)
+        print("Benchmark: alloc_extend_kernel")
+        print("=" * 80)
+        for bs in [1, 4, 16, 64, 256]:
+            for page_size in [1, 16, 128]:
+                BenchmarkScheduler.bench_alloc_extend(bs, page_size)
+
+        print()
+        print("=" * 80)
+        print("Benchmark: alloc_decode_kernel")
+        print("=" * 80)
+        for bs in [1, 4, 16, 64, 256, 1024]:
+            for page_size in [1, 16, 128]:
+                BenchmarkScheduler.bench_alloc_decode(bs, page_size)
+    else:
+        unittest.main()

--- a/test/srt/cpu/test_compressor.py
+++ b/test/srt/cpu/test_compressor.py
@@ -1,0 +1,228 @@
+import itertools
+import time
+import unittest
+
+import torch
+
+from sglang.test.test_utils import CustomTestCase
+
+torch.manual_seed(42)
+
+
+# ───────────────── Reference Python implementation ─────────────────
+
+
+def compute_state_len(seq_len, ratio):
+    return seq_len % ratio + (ratio == 4) * ratio
+
+
+def overlap_transform(tensor, fill_value, ratio, head_dim):
+    """tensor: [S, ratio, 2*head_dim] -> [S, 2*ratio, head_dim]"""
+    s, r, _ = tensor.shape
+    d = head_dim
+    new_tensor = tensor.new_full((s, 2 * r, d), fill_value)
+    new_tensor[:, r:] = tensor[:, :, d:]
+    if s > 1:
+        new_tensor[1:, :r] = tensor[:-1, :, :d]
+    return new_tensor
+
+
+def overlap_transform_decode(tensor, ratio, head_dim):
+    """tensor: [bs, 2*ratio, 2*head_dim] -> [bs, 2*ratio, head_dim]"""
+    r, d = ratio, head_dim
+    return torch.cat((tensor[:, :r, :d], tensor[:, r:, d:]), dim=1)
+
+
+def rmsnorm_ref(x, weight, eps):
+    """RMS norm reference: x is [head_dim], weight is [head_dim]."""
+    x_f32 = x.float()
+    variance = x_f32.pow(2).mean(dim=-1, keepdim=True)
+    return (x_f32 * torch.rsqrt(variance + eps) * weight.float()).float()
+
+
+def apply_rotary_emb_ref(x, freqs):
+    """Interleaved rotary embedding reference. x, freqs are 1D [rope_dim]."""
+    x = x.float().clone()
+    f = freqs.float()
+    for k in range(0, x.size(0), 2):
+        xr, xi = x[k].item(), x[k + 1].item()
+        cr, ci = f[k].item(), f[k + 1].item()
+        x[k] = xr * cr - xi * ci
+        x[k + 1] = xr * ci + xi * cr
+    return x
+
+
+def hadamard_transform_ref(x, scale):
+    n = x.size(-1)
+    out = x.float().clone()
+    h = 1
+    while h < n:
+        for j in range(0, n, 2 * h):
+            for k in range(h):
+                a, b = out[j + k].item(), out[j + k + h].item()
+                out[j + k] = a + b
+                out[j + k + h] = a - b
+        h <<= 1
+    return out * scale
+
+
+def compress_decode_ref(
+    pool_kv, pool_score, kv, score, seq_lens, req_pool_indices,
+    ape, norm_weight, freqs_cis, ratio, head_dim, rope_head_dim,
+    overlap, rotate, norm_eps
+):
+    """Pure Python reference matching compress_decode_old."""
+    bs = kv.size(0)
+    coff = 1 + (1 if overlap else 0)
+    coff_hd = coff * head_dim
+
+    output = torch.empty(bs, head_dim, dtype=torch.float32)
+
+    for b in range(bs):
+        seq_len = seq_lens[b].item()
+        req_idx = req_pool_indices[b].item()
+        write_pos = (seq_len - 1) % ratio + (ratio if overlap else 0)
+
+        pool_kv[req_idx, write_pos] = kv[b]
+        pool_score[req_idx, write_pos] = score[b]
+
+        kv_buf = pool_kv[req_idx].clone()
+        score_buf = pool_score[req_idx].clone()
+
+        if overlap and (seq_len % ratio == 0):
+            pool_kv[req_idx, :ratio] = kv_buf[ratio:]
+            pool_score[req_idx, :ratio] = score_buf[ratio:]
+
+        # Reshape to [coff, ratio, coff_hd] then add APE
+        kv_r = kv_buf.view(coff, ratio, coff_hd)
+        score_r = score_buf.view(coff, ratio, coff_hd)
+        score_r = score_r + ape.unsqueeze(0)
+
+        if overlap:
+            kv_r2 = kv_r.view(1, coff * ratio, coff_hd)
+            score_r2 = score_r.view(1, coff * ratio, coff_hd)
+            kv_r2 = overlap_transform_decode(kv_r2, ratio, head_dim)
+            score_r2 = overlap_transform_decode(score_r2, ratio, head_dim)
+            kv_final = kv_r2.view(ratio * coff, head_dim)
+            score_final = score_r2.view(ratio * coff, head_dim)
+        else:
+            kv_final = kv_r.view(ratio, head_dim)
+            score_final = score_r.view(ratio, head_dim)
+
+        weights = score_final.softmax(dim=0)
+        compressed = (kv_final * weights).sum(dim=0)
+        normed = rmsnorm_ref(compressed, norm_weight, norm_eps)
+
+        freq_pos = (seq_len - 1) // ratio * ratio
+        freq = freqs_cis[freq_pos]
+        normed[-rope_head_dim:] = apply_rotary_emb_ref(normed[-rope_head_dim:], freq)
+
+        if rotate:
+            normed = hadamard_transform_ref(normed, head_dim ** -0.5)
+
+        output[b] = normed
+
+    return output
+
+
+class TestCompressDecodeKernel(CustomTestCase):
+
+    def _make_inputs(self, bs, ratio, head_dim, rope_head_dim, overlap, max_reqs=4, max_seq=256):
+        coff = 1 + (1 if overlap else 0)
+        coff_hd = coff * head_dim
+        state_len = ratio * coff
+
+        pool_kv = torch.randn(max_reqs, state_len, coff_hd, dtype=torch.float32)
+        pool_score = torch.randn(max_reqs, state_len, coff_hd, dtype=torch.float32)
+        kv = torch.randn(bs, coff_hd, dtype=torch.float32)
+        score = torch.randn(bs, coff_hd, dtype=torch.float32)
+
+        seq_lens = torch.randint(ratio, max_seq, (bs,), dtype=torch.int64)
+        req_pool_indices = torch.arange(bs, dtype=torch.int64)
+
+        ape = torch.randn(ratio, coff_hd, dtype=torch.float32)
+        norm_weight = torch.randn(head_dim, dtype=torch.float32).abs() + 0.1
+
+        # freqs_cis: [max_seq, rope_head_dim] interleaved cos/sin
+        freqs_cis = torch.randn(max_seq, rope_head_dim, dtype=torch.float32)
+
+        return (pool_kv, pool_score, kv, score, seq_lens, req_pool_indices,
+                ape, norm_weight, freqs_cis)
+
+    def test_decode_no_overlap(self):
+        bs, ratio, head_dim, rope_head_dim = 4, 128, 256, 64
+        overlap, rotate = False, False
+        norm_eps = 1e-6
+
+        inputs = self._make_inputs(bs, ratio, head_dim, rope_head_dim, overlap)
+        pool_kv, pool_score, kv, score, seq_lens, req_pool_indices, ape, norm_weight, freqs_cis = inputs
+
+        # Reference
+        pool_kv_ref = pool_kv.clone()
+        pool_score_ref = pool_score.clone()
+        ref = compress_decode_ref(
+            pool_kv_ref, pool_score_ref, kv, score, seq_lens, req_pool_indices,
+            ape, norm_weight, freqs_cis, ratio, head_dim, rope_head_dim,
+            overlap, rotate, norm_eps)
+
+        # Kernel
+        pool_kv_kern = pool_kv.clone()
+        pool_score_kern = pool_score.clone()
+        out = torch.ops.sgl_kernel.compress_decode_cpu(
+            pool_kv_kern, pool_score_kern, kv, score, seq_lens, req_pool_indices,
+            ape, norm_weight, freqs_cis, ratio, head_dim, rope_head_dim,
+            overlap, rotate, norm_eps)
+
+        torch.testing.assert_close(ref, out, atol=1e-4, rtol=1e-4)
+
+    def test_decode_with_overlap(self):
+        bs, ratio, head_dim, rope_head_dim = 4, 4, 256, 64
+        overlap, rotate = True, False
+        norm_eps = 1e-6
+
+        inputs = self._make_inputs(bs, ratio, head_dim, rope_head_dim, overlap)
+        pool_kv, pool_score, kv, score, seq_lens, req_pool_indices, ape, norm_weight, freqs_cis = inputs
+
+        pool_kv_ref = pool_kv.clone()
+        pool_score_ref = pool_score.clone()
+        ref = compress_decode_ref(
+            pool_kv_ref, pool_score_ref, kv, score, seq_lens, req_pool_indices,
+            ape, norm_weight, freqs_cis, ratio, head_dim, rope_head_dim,
+            overlap, rotate, norm_eps)
+
+        pool_kv_kern = pool_kv.clone()
+        pool_score_kern = pool_score.clone()
+        out = torch.ops.sgl_kernel.compress_decode_cpu(
+            pool_kv_kern, pool_score_kern, kv, score, seq_lens, req_pool_indices,
+            ape, norm_weight, freqs_cis, ratio, head_dim, rope_head_dim,
+            overlap, rotate, norm_eps)
+
+        torch.testing.assert_close(ref, out, atol=1e-4, rtol=1e-4)
+
+    def test_decode_with_rotate(self):
+        bs, ratio, head_dim, rope_head_dim = 2, 4, 128, 64
+        overlap, rotate = True, True
+        norm_eps = 1e-6
+
+        inputs = self._make_inputs(bs, ratio, head_dim, rope_head_dim, overlap)
+        pool_kv, pool_score, kv, score, seq_lens, req_pool_indices, ape, norm_weight, freqs_cis = inputs
+
+        pool_kv_ref = pool_kv.clone()
+        pool_score_ref = pool_score.clone()
+        ref = compress_decode_ref(
+            pool_kv_ref, pool_score_ref, kv, score, seq_lens, req_pool_indices,
+            ape, norm_weight, freqs_cis, ratio, head_dim, rope_head_dim,
+            overlap, rotate, norm_eps)
+
+        pool_kv_kern = pool_kv.clone()
+        pool_score_kern = pool_score.clone()
+        out = torch.ops.sgl_kernel.compress_decode_cpu(
+            pool_kv_kern, pool_score_kern, kv, score, seq_lens, req_pool_indices,
+            ape, norm_weight, freqs_cis, ratio, head_dim, rope_head_dim,
+            overlap, rotate, norm_eps)
+
+        torch.testing.assert_close(ref, out, atol=1e-3, rtol=1e-3)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/srt/cpu/test_fused_scale_cpu.py
+++ b/test/srt/cpu/test_fused_scale_cpu.py
@@ -1,0 +1,54 @@
+import itertools
+import unittest
+
+import torch
+from sglang.test.test_utils import CustomTestCase
+
+def fused_scale_torch(
+    weight: torch.Tensor,
+    out_scale: float,
+    q_scale: torch.Tensor,
+) -> torch.Tensor:
+    assert weight.is_contiguous() and q_scale.is_contiguous()
+    B, H = weight.shape
+    out_dtype = torch.promote_types(weight.dtype, q_scale.dtype)
+    acc = weight.reshape(-1).float() * out_scale * q_scale.reshape(-1).float()
+    out = acc.to(out_dtype).reshape(B, H, 1)
+    return out
+
+class TestFusedScaleCPU(CustomTestCase):
+    shapes = [(1, 1), (2, 8), (3, 128)]
+    weight_dtypes = [torch.float32, torch.bfloat16, torch.float16]
+
+    def _run_case(self, shape, weight_dtype):
+        torch.manual_seed(1234)
+        weight = torch.randn(shape, dtype=torch.float32).to(weight_dtype).contiguous()
+        # act_quant always emits fp32 scales; the kernel pins q_scale to fp32
+        # and always returns fp32 output.
+        q_scale = torch.rand(shape, dtype=torch.float32).contiguous()
+        out_scale = 0.03125
+
+        ref = fused_scale_torch(weight, out_scale, q_scale)
+        out = torch.ops.sgl_kernel.fused_scale_cpu(weight, out_scale, q_scale)
+
+        self.assertEqual(out.shape, (*shape, 1))
+        self.assertEqual(out.dtype, torch.float32)
+        torch.testing.assert_close(out, ref, atol=0, rtol=0)
+
+    def test_fused_scale_cpu(self):
+        for shape, weight_dtype in itertools.product(self.shapes, self.weight_dtypes):
+            with self.subTest(shape=shape, weight_dtype=weight_dtype):
+                self._run_case(shape, weight_dtype)
+
+    def test_q_scale_view_shape(self):
+        weight = torch.randn((2, 4), dtype=torch.bfloat16).contiguous()
+        q_scale = torch.rand((2, 4, 1), dtype=torch.float32).contiguous()
+
+        ref = fused_scale_torch(weight, 0.5, q_scale)
+        out = torch.ops.sgl_kernel.fused_scale_cpu(weight, 0.5, q_scale)
+
+        torch.testing.assert_close(out, ref, atol=0, rtol=0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/srt/cpu/test_gemm.py
+++ b/test/srt/cpu/test_gemm.py
@@ -327,6 +327,42 @@ class TestGemm(CustomTestCase):
             ):
                 self._int4_gptq_gemm(*params)
 
+    def _bf16_fp32_gemm(self, M, N, K, has_bias):
+        mat1 = torch.randn(M, K, dtype=torch.bfloat16)
+        mat2 = torch.randn(N, K, dtype=torch.bfloat16)
+        bias = torch.randn(N, dtype=torch.float32) if has_bias else None
+
+        ref = torch.nn.functional.linear(
+            mat1.float(), mat2.float(), bias
+        )
+
+        out = torch.ops.sgl_kernel.weight_packed_linear(
+            mat1, mat2, bias, False, torch.float32
+        )
+        self.assertEqual(out.dtype, torch.float32)
+        atol = rtol = precision[torch.float32]
+        torch.testing.assert_close(ref, out, atol=atol, rtol=rtol)
+
+        packed_mat2 = torch.ops.sgl_kernel.convert_weight_packed(mat2)
+        out2 = torch.ops.sgl_kernel.weight_packed_linear(
+            mat1, packed_mat2, bias, True, torch.float32
+        )
+        self.assertEqual(out2.dtype, torch.float32)
+        torch.testing.assert_close(ref, out2, atol=atol, rtol=rtol)
+
+    def test_bf16_fp32_gemm(self):
+        for params in itertools.product(
+            self.M, self.N, self.K, self.has_bias
+                    ):
+            with self.subTest(
+                M=params[0],
+                N=params[1],
+                K=params[2],
+                has_bias=params[3],
+            ):
+                self._bf16_fp32_gemm(*params)
+
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/srt/cpu/test_hadamard.py
+++ b/test/srt/cpu/test_hadamard.py
@@ -1,0 +1,98 @@
+import itertools
+import unittest
+
+import torch
+from utils import precision
+
+from sglang.test.test_utils import CustomTestCase
+
+torch.manual_seed(42)
+
+
+def _torch_hadamard_transform(x: torch.Tensor, scale: float) -> torch.Tensor:
+    """Reference pure-torch FWHT implementation."""
+    n = x.size(-1)
+    leading = x.shape[:-1]
+    out = x.reshape(-1, n).float().clone()
+    h = 1
+    while h < n:
+        out = out.view(-1, n // (2 * h), 2, h)
+        a = out[:, :, 0, :]
+        b = out[:, :, 1, :]
+        out = torch.stack((a + b, a - b), dim=2).view(-1, n)
+        h *= 2
+    return (out.view(*leading, n) * scale).to(x.dtype)
+
+
+class TestHadamardTransform(CustomTestCase):
+    # Last dim must be power of 2
+    N = [2, 4, 8, 16, 32, 64, 128, 256, 512, 1024]
+    BATCH = [1, 3, 7, 16]
+    DTYPE = [torch.float32, torch.bfloat16, torch.float16]
+
+    def _test_hadamard(self, batch, n, dtype):
+        x = torch.randn([batch, n], dtype=dtype)
+        scale = n**-0.5
+
+        out = torch.ops.sgl_kernel.fast_hadamard_transform_cpu(x, scale)
+        ref = _torch_hadamard_transform(x, scale)
+
+        atol = rtol = precision[dtype]
+        torch.testing.assert_close(ref, out, atol=atol, rtol=rtol)
+
+    def test_basic(self):
+        """Test across various batch sizes, dimensions, and dtypes."""
+        for params in itertools.product(self.BATCH, self.N, self.DTYPE):
+            with self.subTest(batch=params[0], n=params[1], dtype=params[2]):
+                self._test_hadamard(*params)
+
+    def test_3d_input(self):
+        """Test with 3-D input tensor (e.g. [B, S, D])."""
+        for n in [32, 64, 128, 256]:
+            for dtype in [torch.bfloat16, torch.float32]:
+                x = torch.randn([2, 8, n], dtype=dtype)
+                scale = n**-0.5
+                out = torch.ops.sgl_kernel.fast_hadamard_transform_cpu(x, scale)
+                ref = _torch_hadamard_transform(x, scale)
+                atol = rtol = precision[dtype]
+                torch.testing.assert_close(ref, out, atol=atol, rtol=rtol)
+
+    def test_4d_input(self):
+        """Test with 4-D input tensor (e.g. [B, H, S, D])."""
+        for n in [32, 128]:
+            x = torch.randn([2, 4, 8, n], dtype=torch.bfloat16)
+            scale = n**-0.5
+            out = torch.ops.sgl_kernel.fast_hadamard_transform_cpu(x, scale)
+            ref = _torch_hadamard_transform(x, scale)
+            atol = rtol = precision[torch.bfloat16]
+            torch.testing.assert_close(ref, out, atol=atol, rtol=rtol)
+
+    def test_scale_one(self):
+        """Test with scale=1.0 (no scaling)."""
+        x = torch.randn([4, 64], dtype=torch.float32)
+        out = torch.ops.sgl_kernel.fast_hadamard_transform_cpu(x, 1.0)
+        ref = _torch_hadamard_transform(x, 1.0)
+        torch.testing.assert_close(ref, out, atol=1e-5, rtol=1e-5)
+
+    def test_large_dim(self):
+        """Test with large last dimension typical of LLM hidden sizes."""
+        for n in [2048, 4096]:
+            x = torch.randn([2, n], dtype=torch.bfloat16)
+            scale = n**-0.5
+            out = torch.ops.sgl_kernel.fast_hadamard_transform_cpu(x, scale)
+            ref = _torch_hadamard_transform(x, scale)
+            atol = rtol = precision[torch.bfloat16]
+            torch.testing.assert_close(ref, out, atol=atol, rtol=rtol)
+
+    def test_involution(self):
+        """FWHT applied twice (with scale=1/n) should recover the original."""
+        n = 128
+        x = torch.randn([4, n], dtype=torch.float32)
+        # H * H = n * I, so applying twice with scale 1/n gives identity.
+        y = torch.ops.sgl_kernel.fast_hadamard_transform_cpu(x, 1.0)
+        z = torch.ops.sgl_kernel.fast_hadamard_transform_cpu(y, 1.0 / n)
+        torch.testing.assert_close(x, z, atol=1e-4, rtol=1e-4)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/srt/cpu/test_moe.py
+++ b/test/srt/cpu/test_moe.py
@@ -17,6 +17,7 @@ from utils import (
     factor_for_scale,
     fp8_max,
     fp8_min,
+    native_clamped_silu_fused_moe,
     native_fp8_fused_moe,
     parametrize,
     precision,
@@ -361,6 +362,56 @@ class TestFusedExperts(CustomTestCase):
         )
         atol = rtol = precision[torch_output.dtype]
         torch.testing.assert_close(torch_output, fused_output, atol=atol, rtol=rtol)
+
+    @parametrize(M=[1, 16], N=[256], K=[512], E=[8], topk=[6], limit=[None, 10.0])
+    def test_mxfp4_moe_dsv4(self, M, N, K, E, topk, limit):
+        dtype = torch.bfloat16
+
+        a = torch.randn(M, K, dtype=dtype) / 10
+
+        w1_bf16 = torch.randn((E, 2 * N, K), dtype=dtype) / 10
+        w1q, w1s = MXFP4QuantizeUtil.quantize(w1_bf16)
+        w1s = w1s.reshape(E, 2 * N, K // 32)
+        w1dq = MXFP4QuantizeUtil.dequantize(w1q, dtype, w1s)
+
+        w2_bf16 = torch.randn((E, K, N), dtype=dtype) / 10
+        w2q, w2s = MXFP4QuantizeUtil.quantize(w2_bf16)
+        w2s = w2s.reshape(E, K, N // 32)
+        w2dq = MXFP4QuantizeUtil.dequantize(w2q, dtype, w2s)
+
+        score = torch.softmax(
+            torch.randn((M, E), dtype=dtype), dim=-1, dtype=torch.float32
+        )
+        topk_weight, topk_ids = torch.topk(score, topk)
+
+        if limit is None:
+            ref = native_fp8_fused_moe(
+                a, w1dq.float(), w2dq.float(), topk_weight, topk_ids, topk
+            )
+        else:
+            ref = native_clamped_silu_fused_moe(
+                a, w1dq.float(), w2dq.float(), topk_weight, topk_ids, topk, limit
+            )
+
+        w1 = kernel.convert_weight_packed(w1q)
+        w2 = kernel.convert_weight_packed(w2q)
+        w1s = kernel.convert_scale_packed(w1s)
+        w2s = kernel.convert_scale_packed(w2s)
+
+        out = kernel.fused_experts_cpu(
+            a, w1, w2, topk_weight, topk_ids.to(torch.int32),
+            False,                   # inplace
+            CPUQuantMethod.MXFP4,
+            w1s, w2s,
+            None, None, None,        # w1_zp, w2_zp, block_size
+            None, None,              # w1_bias, w2_bias  (DSV4 has no bias)
+            None,                    # gemm1_alpha       (2604B has no alpha)
+            limit,                   # gemm1_clamp_limit (None for 2604; float for 2604B)
+            True,                    # is_vnni
+        )
+
+        atol = rtol = precision[dtype]
+        torch.testing.assert_close(ref.bfloat16(), out, atol=atol, rtol=rtol)
 
     @parametrize(M=[1, 6], N=[512], K=[256], E=[8], topk=[4])
     def test_int4_moe(self, M, N, K, E, topk, group_size=128):

--- a/test/srt/cpu/test_moe.py
+++ b/test/srt/cpu/test_moe.py
@@ -1,4 +1,3 @@
-import itertools
 import math
 import unittest
 
@@ -9,18 +8,21 @@ from sglang.srt.layers.amx_utils import CPUQuantMethod
 
 kernel = torch.ops.sgl_kernel
 
-torch.manual_seed(128)
+torch.manual_seed(1234)
 
 from utils import (
     BLOCK_K,
     BLOCK_N,
+    MXFP4QuantizeUtil,
     factor_for_scale,
     fp8_max,
     fp8_min,
     native_fp8_fused_moe,
+    parametrize,
     precision,
     scaled_weight,
     torch_naive_fused_moe,
+    torch_naive_fused_moe_gptoss,
     torch_w8a8_per_column_fused_moe,
     unpack_and_dequant_awq,
 )
@@ -57,37 +59,18 @@ def fused_moe(a, w1, w2, score, topk, renormalize, prepack):
         None,
         None,
         None,
+        None,
+        None,
+        None,
+        None,
         prepack,
     )
 
 
 class TestFusedExperts(CustomTestCase):
-    M = [2, 114]
-    N = [32]
-    K = [32]
-    E = [4]
-    topk = [2]
-    renormalize = [False, True]
 
-    M_int8 = [1, 39]
-    N_int8 = [128]
-    K_int8 = [256]
-    E_int8 = [8]
-    topk_int8 = [3]
-
-    M_fp8 = [2, 121]
-    N_fp8 = [352, 512]
-    K_fp8 = [256, 320]
-    E_fp8 = [8]
-    topk_fp8 = [4]
-
-    M_int4 = [1, 6]
-    N_int4 = [512]
-    K_int4 = [256]
-    E_int4 = [8]
-    topk_int4 = [4]
-
-    def _bf16_moe(self, m, n, k, e, topk, renormalize):
+    @parametrize(m=[2, 114], n=[32], k=[32], e=[4], topk=[2], renormalize=[False, True])
+    def test_bf16_moe(self, m, n, k, e, topk, renormalize):
         dtype = torch.bfloat16
         prepack = True
 
@@ -102,26 +85,51 @@ class TestFusedExperts(CustomTestCase):
         atol = rtol = precision[torch_output.dtype]
         torch.testing.assert_close(torch_output, fused_output, atol=atol, rtol=rtol)
 
-    def test_bf16_moe(self):
-        for params in itertools.product(
-            self.M,
-            self.N,
-            self.K,
-            self.E,
-            self.topk,
-            self.renormalize,
-        ):
-            with self.subTest(
-                m=params[0],
-                n=params[1],
-                k=params[2],
-                e=params[3],
-                topk=params[4],
-                renormalize=params[5],
-            ):
-                self._bf16_moe(*params)
+    @parametrize(
+        m=[1, 32], n=[128, 64], k=[128, 64], e=[4], topk=[2], renormalize=[False]
+    )
+    def test_bf16_moe_bias(self, m, n, k, e, topk, renormalize):
+        dtype = torch.bfloat16
 
-    def _int8_moe(self, M, N, K, E, topk):
+        a = torch.randn((m, k), device="cpu", dtype=dtype) / 10
+        w1 = torch.randn((e, 2 * n, k), device="cpu", dtype=dtype) / 10
+        w1_b = torch.randn((e, 2 * n), device="cpu", dtype=torch.float) / 10
+        w2 = torch.randn((e, k, n), device="cpu", dtype=dtype) / 10
+        w2_b = torch.randn((e, k), device="cpu", dtype=torch.float) / 10
+        score = torch.randn((m, e), device="cpu", dtype=dtype)
+        score = torch.softmax(score, dim=-1, dtype=torch.float32)
+        topk_weight, topk_ids = torch.topk(score, topk)
+        alpha = 1.702
+        limit = 7.0
+        torch_output = torch_naive_fused_moe_gptoss(
+            a, w1, w2, w1_b, w2_b, topk_weight, topk_ids, renormalize, alpha, limit, e
+        )
+        packed_w1 = kernel.convert_weight_packed(w1)
+        packed_w2 = kernel.convert_weight_packed(w2)
+        fused_output = torch.ops.sgl_kernel.fused_experts_cpu(
+            a,
+            packed_w1,
+            packed_w2,
+            topk_weight,
+            topk_ids.to(torch.int),
+            False,  # inplace # See [Note] inplace should be False in fused_experts.
+            CPUQuantMethod.UNQUANT,
+            None,  # w1_scale
+            None,  # w2_scale
+            None,  # w1_zp
+            None,  # w2_zp
+            None,  # block_size
+            w1_b,
+            w2_b,
+            alpha,
+            limit,
+            True,  # is_vnni
+        )
+        atol = rtol = precision[torch_output.dtype]
+        torch.testing.assert_close(torch_output, fused_output, atol=atol, rtol=rtol)
+
+    @parametrize(M=[1, 39], N=[128], K=[256], E=[8], topk=[3])
+    def test_int8_moe(self, M, N, K, E, topk):
         dtype = torch.bfloat16
         prepack = True
 
@@ -170,6 +178,10 @@ class TestFusedExperts(CustomTestCase):
             None,
             None,
             None,
+            None,
+            None,
+            None,
+            None,
             prepack,
         )
 
@@ -179,24 +191,8 @@ class TestFusedExperts(CustomTestCase):
             atol = rtol = 0.02
         torch.testing.assert_close(ref_out, out, atol=atol, rtol=rtol)
 
-    def test_int8_moe(self):
-        for params in itertools.product(
-            self.M_int8,
-            self.N_int8,
-            self.K_int8,
-            self.E_int8,
-            self.topk_int8,
-        ):
-            with self.subTest(
-                M=params[0],
-                N=params[1],
-                K=params[2],
-                E=params[3],
-                topk=params[4],
-            ):
-                self._int8_moe(*params)
-
-    def _fp8_moe(self, M, N, K, E, topk):
+    @parametrize(M=[2, 121], N=[352, 512], K=[256, 320], E=[8], topk=[4])
+    def test_fp8_moe(self, M, N, K, E, topk):
         dtype = torch.bfloat16
 
         a = torch.randn(M, K, dtype=dtype) / math.sqrt(K)
@@ -242,30 +238,132 @@ class TestFusedExperts(CustomTestCase):
             None,
             None,
             [BLOCK_N, BLOCK_K],
+            None,
+            None,
+            None,
+            None,
             True,
         )
 
         atol = rtol = precision[dtype]
         torch.testing.assert_close(ref_out.bfloat16(), out, atol=atol, rtol=rtol)
 
-    def test_fp8_moe(self):
-        for params in itertools.product(
-            self.M_fp8,
-            self.N_fp8,
-            self.K_fp8,
-            self.E_fp8,
-            self.topk_fp8,
-        ):
-            with self.subTest(
-                M=params[0],
-                N=params[1],
-                K=params[2],
-                E=params[3],
-                topk=params[4],
-            ):
-                self._fp8_moe(*params)
+    @parametrize(M=[2, 121], N=[352, 512], K=[256, 320], E=[8], topk=[4])
+    def test_mxfp4_moe(self, M, N, K, E, topk):
+        dtype = torch.bfloat16
 
-    def _int4_moe(self, M, N, K, E, topk, group_size=128):
+        a = torch.randn(M, K, dtype=dtype) / 10
+
+        w1_bf16 = torch.randn((E, 2 * N, K), dtype=dtype) / 10
+        w1q, w1s = MXFP4QuantizeUtil.quantize(w1_bf16)
+        w1s = w1s.reshape(E, 2 * N, K // 32)
+        w1dq = MXFP4QuantizeUtil.dequantize(w1q, dtype, w1s)
+
+        w2_bf16 = torch.randn((E, K, N), dtype=dtype) / 10
+        w2q, w2s = MXFP4QuantizeUtil.quantize(w2_bf16)
+        w2s = w2s.reshape(E, K, N // 32)
+        w2dq = MXFP4QuantizeUtil.dequantize(w2q, dtype, w2s)
+
+        score = torch.randn((M, E), dtype=dtype)
+        score = torch.softmax(score, dim=-1, dtype=torch.float32)
+        topk_weight, topk_ids = torch.topk(score, topk)
+
+        w1 = kernel.convert_weight_packed(w1q)
+        w2 = kernel.convert_weight_packed(w2q)
+        w1s = kernel.convert_scale_packed(w1s)
+        w2s = kernel.convert_scale_packed(w2s)
+
+        ref_out = native_fp8_fused_moe(
+            a, w1dq.float(), w2dq.float(), topk_weight, topk_ids, topk
+        )
+        out = kernel.fused_experts_cpu(
+            a,
+            w1,
+            w2,
+            topk_weight,
+            topk_ids.to(torch.int32),
+            False,
+            CPUQuantMethod.MXFP4,
+            w1s,
+            w2s,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            True,
+        )
+
+        atol = rtol = precision[dtype]
+        torch.testing.assert_close(ref_out.bfloat16(), out, atol=atol, rtol=rtol)
+
+    @parametrize(
+        m=[1, 32], n=[128, 64], k=[128, 64], e=[4], topk=[2], renormalize=[False]
+    )
+    def test_mxfp4_moe_bias(self, m, n, k, e, topk, renormalize):
+        dtype = torch.bfloat16
+
+        a = torch.randn((m, k), device="cpu", dtype=dtype) / 10
+        w1_bf16 = torch.randn((e, 2 * n, k), device="cpu", dtype=dtype) / 10
+        w1q, w1s = MXFP4QuantizeUtil.quantize(w1_bf16)
+        w1s = w1s.reshape(e, 2 * n, k // 32)
+        w1dq = MXFP4QuantizeUtil.dequantize(w1q, dtype, w1s)
+        w1_b = torch.randn((e, 2 * n), device="cpu", dtype=torch.float32) / 10
+        w2_bf16 = torch.randn((e, k, n), device="cpu", dtype=dtype) / 10
+        w2q, w2s = MXFP4QuantizeUtil.quantize(w2_bf16)
+        w2s = w2s.reshape(e, k, n // 32)
+        w2dq = MXFP4QuantizeUtil.dequantize(w2q, dtype, w2s)
+        w2_b = torch.randn((e, k), device="cpu", dtype=torch.float32) / 10
+        score = torch.randn((m, e), device="cpu", dtype=dtype)
+        score = torch.softmax(score, dim=-1, dtype=torch.float32)
+        topk_weight, topk_ids = torch.topk(score, topk)
+        alpha = 1.702
+        limit = 7.0
+        torch_output = torch_naive_fused_moe_gptoss(
+            a,
+            w1dq,
+            w2dq,
+            w1_b,
+            w2_b,
+            topk_weight,
+            topk_ids,
+            renormalize,
+            alpha,
+            limit,
+            e,
+        )
+
+        w1 = kernel.convert_weight_packed(w1q)
+        w2 = kernel.convert_weight_packed(w2q)
+        w1s = kernel.convert_scale_packed(w1s)
+        w2s = kernel.convert_scale_packed(w2s)
+
+        fused_output = torch.ops.sgl_kernel.fused_experts_cpu(
+            a,
+            w1,
+            w2,
+            topk_weight,
+            topk_ids.to(torch.int32),
+            False,  # inplace # See [Note] inplace should be False in fused_experts.
+            CPUQuantMethod.MXFP4,  # use_mxfp4
+            w1s,  # w1_scale
+            w2s,  # w2_scale
+            None,  # w1_zp
+            None,  # w2_zp
+            None,  # block_size
+            w1_b,
+            w2_b,
+            alpha,
+            limit,
+            True,  # is_vnni
+        )
+        atol = rtol = precision[torch_output.dtype]
+        torch.testing.assert_close(torch_output, fused_output, atol=atol, rtol=rtol)
+
+    @parametrize(M=[1, 6], N=[512], K=[256], E=[8], topk=[4])
+    def test_int4_moe(self, M, N, K, E, topk, group_size=128):
         dtype = torch.bfloat16
 
         a = torch.rand(M, K, dtype=dtype) / math.sqrt(K)
@@ -324,28 +422,15 @@ class TestFusedExperts(CustomTestCase):
             awq_w13_zero_pack,
             awq_w2_zero_pack,
             None,
+            None,
+            None,
+            None,
+            None,
             True,
         )
 
         atol = rtol = precision[dtype]
         torch.testing.assert_close(ref_out.bfloat16(), out, atol=atol, rtol=rtol)
-
-    def test_int4_moe(self):
-        for params in itertools.product(
-            self.M_int4,
-            self.N_int4,
-            self.K_int4,
-            self.E_int4,
-            self.topk_int4,
-        ):
-            with self.subTest(
-                M=params[0],
-                N=params[1],
-                K=params[2],
-                E=params[3],
-                topk=params[4],
-            ):
-                self._int4_moe(*params)
 
 
 if __name__ == "__main__":

--- a/test/srt/cpu/test_shared_expert.py
+++ b/test/srt/cpu/test_shared_expert.py
@@ -19,18 +19,25 @@ from utils import (
     per_token_quant_int8,
     precision,
     scaled_weight,
+    torch_naive_clamped_silu_moe,
     torch_naive_moe,
     torch_w8a8_per_column_moe,
 )
-
-from sglang.test.test_utils import CustomTestCase
 
 torch.manual_seed(1234)
 
 
 class TestSharedExpert(CustomTestCase):
-    @parametrize(m=[2, 121], n=[32, 32 * 4], k=[32, 32 * 2], routed_scaling_factor=[16], apply_scaling_factor=[True, False])
-    def test_bf16_shared_expert(self, m, n, k, routed_scaling_factor, apply_scaling_factor):
+    @parametrize(
+        m=[2, 121],
+        n=[32, 32 * 4],
+        k=[32, 32 * 2],
+        routed_scaling_factor=[16],
+        apply_scaling_factor=[True, False],
+    )
+    def test_bf16_shared_expert(
+        self, m, n, k, routed_scaling_factor, apply_scaling_factor
+    ):
         dtype = torch.bfloat16
 
         hidden_states = torch.randn(m, k, dtype=dtype) / k
@@ -66,14 +73,24 @@ class TestSharedExpert(CustomTestCase):
             None,
             None,
             None,
+            None,
+            None,
             False,
         )
 
         atol = rtol = precision[ref.dtype]
         torch.testing.assert_close(ref, out, atol=atol, rtol=rtol)
 
-    @parametrize(m=[2, 121], n=[32, 32 * 4], k=[32, 32 * 2], routed_scaling_factor=[16], apply_scaling_factor=[True, False])
-    def test_int8_shared_expert(self, m, n, k, routed_scaling_factor, apply_scaling_factor):
+    @parametrize(
+        m=[2, 121],
+        n=[32, 32 * 4],
+        k=[32, 32 * 2],
+        routed_scaling_factor=[16],
+        apply_scaling_factor=[True, False],
+    )
+    def test_int8_shared_expert(
+        self, m, n, k, routed_scaling_factor, apply_scaling_factor
+    ):
         dtype = torch.bfloat16
 
         hidden_states = torch.randn(m, k, dtype=dtype) / k
@@ -111,6 +128,8 @@ class TestSharedExpert(CustomTestCase):
             w1_s,
             w2_s,
             None,
+            None,
+            None,
             False,
         )
 
@@ -122,9 +141,11 @@ class TestSharedExpert(CustomTestCase):
         n=[512],
         k=[256],
         routed_scaling_factor=[16],
-        apply_scaling_factor=[True, False]
+        apply_scaling_factor=[True, False],
     )
-    def test_fp8_shared_expert(self, m, n, k, routed_scaling_factor, apply_scaling_factor):
+    def test_fp8_shared_expert(
+        self, m, n, k, routed_scaling_factor, apply_scaling_factor
+    ):
         dtype = torch.bfloat16
 
         hidden_states = torch.randn(m, k, dtype=dtype) / math.sqrt(k)
@@ -179,6 +200,92 @@ class TestSharedExpert(CustomTestCase):
             w1s,
             w2s,
             [BLOCK_N, BLOCK_K],
+            None,
+            None,
+            True,
+        )
+
+        atol = rtol = precision[ref.dtype]
+        torch.testing.assert_close(ref, out, atol=atol, rtol=rtol)
+
+    @parametrize(
+        m=[2, 12],
+        n=[512],
+        k=[256],
+        routed_scaling_factor=[16],
+        apply_scaling_factor=[True, False],
+        limit=[None, 10.0],
+    )
+    def test_fp8_shared_expert_dsv4(
+        self, m, n, k, routed_scaling_factor, apply_scaling_factor, limit
+    ):
+        dtype = torch.bfloat16
+
+        hidden_states = torch.randn(m, k, dtype=dtype) / math.sqrt(k)
+
+        w1_fp32 = torch.randn(1, 2 * n, k)
+        w1 = (w1_fp32 * fp8_max).clamp(min=fp8_min, max=fp8_max).to(torch.float8_e4m3fn)
+
+        w2_fp32 = torch.randn(1, k, n)
+        w2 = (w2_fp32 * fp8_max).clamp(min=fp8_min, max=fp8_max).to(torch.float8_e4m3fn)
+
+        w1s = torch.randn(1, 2 * n // BLOCK_N, k // BLOCK_K) * factor_for_scale
+        w2s = torch.randn(1, k // BLOCK_N, n // BLOCK_K) * factor_for_scale
+
+        w1_scaled = scaled_weight(w1, w1s).view(2 * n, k)
+        w2_scaled = scaled_weight(w2, w2s).view(k, n)
+
+        # change back to 2D
+        w1, w2 = w1.squeeze(0), w2.squeeze(0)
+        w1s, w2s = w1s.squeeze(0), w2s.squeeze(0)
+        w1_scaled, w2_scaled = w1_scaled.squeeze(0), w2_scaled.squeeze(0)
+
+        fused_output = (
+            torch.randn(m, k, dtype=dtype) / math.sqrt(k)
+            if apply_scaling_factor
+            else None
+        )
+        routed_scaling_factor = routed_scaling_factor if apply_scaling_factor else None
+        hidden_states2 = hidden_states.clone()
+
+        # ref with bfloat16
+        if limit is None:
+            ref = torch_naive_moe(
+                hidden_states,
+                w1_scaled,
+                w2_scaled,
+                fused_output,
+                routed_scaling_factor,
+                output_dtype=dtype,
+            )
+        else:
+            ref = torch_naive_clamped_silu_moe(
+                hidden_states,
+                w1_scaled,
+                w2_scaled,
+                fused_output,
+                routed_scaling_factor,
+                limit,
+                output_dtype=dtype,
+            )
+
+        w1 = torch.ops.sgl_kernel.convert_weight_packed(w1)  # [2N, K]
+        w2 = torch.ops.sgl_kernel.convert_weight_packed(w2)  # [K, N]
+        out = torch.ops.sgl_kernel.shared_expert_cpu(
+            hidden_states2,
+            w1,
+            w2,
+            fused_output,
+            routed_scaling_factor,
+            True,
+            False,
+            True,
+            False,
+            w1s,
+            w2s,
+            [BLOCK_N, BLOCK_K],
+            None,
+            limit,
             True,
         )
 
@@ -190,9 +297,11 @@ class TestSharedExpert(CustomTestCase):
         N=[512],
         K=[256],
         routed_scaling_factor=[16],
-        apply_scaling_factor=[True, False]
+        apply_scaling_factor=[True, False],
     )
-    def test_mxfp4_shared_expert(self, M, N, K, routed_scaling_factor, apply_scaling_factor):
+    def test_mxfp4_shared_expert(
+        self, M, N, K, routed_scaling_factor, apply_scaling_factor
+    ):
         set_global_server_args_for_scheduler(ServerArgs(model_path="dummy"))
 
         dtype = torch.bfloat16
@@ -210,7 +319,11 @@ class TestSharedExpert(CustomTestCase):
         w2s = w2s.reshape(1, K, N // 32)
         w2dq = MXFP4QuantizeUtil.dequantize(w2q, torch.float32, w2s)
 
-        fused_out = torch.randn(M, K, dtype=dtype) / math.sqrt(K) if apply_scaling_factor else None
+        fused_out = (
+            torch.randn(M, K, dtype=dtype) / math.sqrt(K)
+            if apply_scaling_factor
+            else None
+        )
         routed_scaling_factor = routed_scaling_factor if apply_scaling_factor else None
         a2 = a.clone()
 
@@ -218,7 +331,9 @@ class TestSharedExpert(CustomTestCase):
         ic0 = torch.matmul(a.float(), w1dq.squeeze(0).transpose(0, 1))
         ic1 = SiluAndMul(ic0)
         shared_out = torch.matmul(ic1, w2dq.squeeze(0).transpose(0, 1))
-        ref_out = shared_out + (fused_out.float() * routed_scaling_factor if apply_scaling_factor else 0)
+        ref_out = shared_out + (
+            fused_out.float() * routed_scaling_factor if apply_scaling_factor else 0
+        )
         ref_out = ref_out.to(dtype=dtype)
 
         # change back to 2D
@@ -242,6 +357,8 @@ class TestSharedExpert(CustomTestCase):
             w1s,
             w2s,
             [BLOCK_N, BLOCK_K],
+            None,
+            None,
             True,
         )
 

--- a/test/srt/cpu/test_shared_expert.py
+++ b/test/srt/cpu/test_shared_expert.py
@@ -1,14 +1,21 @@
-import itertools
 import math
 import unittest
 
 import torch
+
+kernel = torch.ops.sgl_kernel
+
+from sglang.srt.server_args import ServerArgs, set_global_server_args_for_scheduler
+from sglang.test.test_utils import CustomTestCase
 from utils import (
     BLOCK_K,
     BLOCK_N,
+    MXFP4QuantizeUtil,
+    SiluAndMul,
     factor_for_scale,
     fp8_max,
     fp8_min,
+    parametrize,
     per_token_quant_int8,
     precision,
     scaled_weight,
@@ -22,17 +29,8 @@ torch.manual_seed(1234)
 
 
 class TestSharedExpert(CustomTestCase):
-    M = [2, 121]
-    N = [32, 32 * 4]
-    K = [32, 32 * 2]
-    routed_scaling_factor = [16]
-    apply_scaling_factor = [True, False]
-
-    M_fp8 = [2, 12]
-    N_fp8 = [512]
-    K_fp8 = [256]
-
-    def _bf16_shared_expert(self, m, n, k, routed_scaling_factor, apply_scaling_factor):
+    @parametrize(m=[2, 121], n=[32, 32 * 4], k=[32, 32 * 2], routed_scaling_factor=[16], apply_scaling_factor=[True, False])
+    def test_bf16_shared_expert(self, m, n, k, routed_scaling_factor, apply_scaling_factor):
         dtype = torch.bfloat16
 
         hidden_states = torch.randn(m, k, dtype=dtype) / k
@@ -64,6 +62,7 @@ class TestSharedExpert(CustomTestCase):
             True,
             False,
             False,
+            False,
             None,
             None,
             None,
@@ -73,24 +72,8 @@ class TestSharedExpert(CustomTestCase):
         atol = rtol = precision[ref.dtype]
         torch.testing.assert_close(ref, out, atol=atol, rtol=rtol)
 
-    def test_bf16_shared_expert(self):
-        for params in itertools.product(
-            self.M,
-            self.N,
-            self.K,
-            self.routed_scaling_factor,
-            self.apply_scaling_factor,
-        ):
-            with self.subTest(
-                m=params[0],
-                n=params[1],
-                k=params[2],
-                routed_scaling_factor=params[3],
-                apply_scaling_factor=params[4],
-            ):
-                self._bf16_shared_expert(*params)
-
-    def _int8_shared_expert(self, m, n, k, routed_scaling_factor, apply_scaling_factor):
+    @parametrize(m=[2, 121], n=[32, 32 * 4], k=[32, 32 * 2], routed_scaling_factor=[16], apply_scaling_factor=[True, False])
+    def test_int8_shared_expert(self, m, n, k, routed_scaling_factor, apply_scaling_factor):
         dtype = torch.bfloat16
 
         hidden_states = torch.randn(m, k, dtype=dtype) / k
@@ -124,6 +107,7 @@ class TestSharedExpert(CustomTestCase):
             True,
             True,
             False,
+            False,
             w1_s,
             w2_s,
             None,
@@ -133,24 +117,14 @@ class TestSharedExpert(CustomTestCase):
         atol = rtol = precision[ref.dtype]
         torch.testing.assert_close(ref, out, atol=atol, rtol=rtol)
 
-    def test_int8_shared_expert(self):
-        for params in itertools.product(
-            self.M,
-            self.N,
-            self.K,
-            self.routed_scaling_factor,
-            self.apply_scaling_factor,
-        ):
-            with self.subTest(
-                m=params[0],
-                n=params[1],
-                k=params[2],
-                routed_scaling_factor=params[3],
-                apply_scaling_factor=params[4],
-            ):
-                self._int8_shared_expert(*params)
-
-    def _fp8_shared_expert(self, m, n, k, routed_scaling_factor, apply_scaling_factor):
+    @parametrize(
+        m=[2, 12],
+        n=[512],
+        k=[256],
+        routed_scaling_factor=[16],
+        apply_scaling_factor=[True, False]
+    )
+    def test_fp8_shared_expert(self, m, n, k, routed_scaling_factor, apply_scaling_factor):
         dtype = torch.bfloat16
 
         hidden_states = torch.randn(m, k, dtype=dtype) / math.sqrt(k)
@@ -201,6 +175,7 @@ class TestSharedExpert(CustomTestCase):
             True,
             False,
             True,
+            False,
             w1s,
             w2s,
             [BLOCK_N, BLOCK_K],
@@ -210,22 +185,68 @@ class TestSharedExpert(CustomTestCase):
         atol = rtol = precision[ref.dtype]
         torch.testing.assert_close(ref, out, atol=atol, rtol=rtol)
 
-    def test_fp8_shared_expert(self):
-        for params in itertools.product(
-            self.M_fp8,
-            self.N_fp8,
-            self.K_fp8,
-            self.routed_scaling_factor,
-            self.apply_scaling_factor,
-        ):
-            with self.subTest(
-                m=params[0],
-                n=params[1],
-                k=params[2],
-                routed_scaling_factor=params[3],
-                apply_scaling_factor=params[4],
-            ):
-                self._fp8_shared_expert(*params)
+    @parametrize(
+        M=[2, 12],
+        N=[512],
+        K=[256],
+        routed_scaling_factor=[16],
+        apply_scaling_factor=[True, False]
+    )
+    def test_mxfp4_shared_expert(self, M, N, K, routed_scaling_factor, apply_scaling_factor):
+        set_global_server_args_for_scheduler(ServerArgs(model_path="dummy"))
+
+        dtype = torch.bfloat16
+        prepack = True
+
+        a = torch.randn(M, K, dtype=dtype) / math.sqrt(K)
+
+        w1_fp32 = torch.randn(1, 2 * N, K) / 10
+        w1q, w1s = MXFP4QuantizeUtil.quantize(w1_fp32)
+        w1s = w1s.reshape(1, 2 * N, K // 32)
+        w1dq = MXFP4QuantizeUtil.dequantize(w1q, torch.float32, w1s)
+
+        w2_fp32 = torch.randn(1, K, N) / 10
+        w2q, w2s = MXFP4QuantizeUtil.quantize(w2_fp32)
+        w2s = w2s.reshape(1, K, N // 32)
+        w2dq = MXFP4QuantizeUtil.dequantize(w2q, torch.float32, w2s)
+
+        fused_out = torch.randn(M, K, dtype=dtype) / math.sqrt(K) if apply_scaling_factor else None
+        routed_scaling_factor = routed_scaling_factor if apply_scaling_factor else None
+        a2 = a.clone()
+
+        # ref
+        ic0 = torch.matmul(a.float(), w1dq.squeeze(0).transpose(0, 1))
+        ic1 = SiluAndMul(ic0)
+        shared_out = torch.matmul(ic1, w2dq.squeeze(0).transpose(0, 1))
+        ref_out = shared_out + (fused_out.float() * routed_scaling_factor if apply_scaling_factor else 0)
+        ref_out = ref_out.to(dtype=dtype)
+
+        # change back to 2D
+        w1q, w2q = w1q.squeeze(0), w2q.squeeze(0)
+        w1s, w2s = w1s.squeeze(0), w2s.squeeze(0)
+
+        w1 = kernel.convert_weight_packed(w1q)
+        w2 = kernel.convert_weight_packed(w2q)
+        w1s = kernel.convert_scale_packed(w1s)
+        w2s = kernel.convert_scale_packed(w2s)
+        out = torch.ops.sgl_kernel.shared_expert_cpu(
+            a2,
+            w1,
+            w2,
+            fused_out,
+            routed_scaling_factor,
+            True,
+            False,
+            False,
+            True,
+            w1s,
+            w2s,
+            [BLOCK_N, BLOCK_K],
+            True,
+        )
+
+        atol = rtol = precision[ref_out.dtype]
+        torch.testing.assert_close(ref_out, out, atol=atol, rtol=rtol)
 
 
 if __name__ == "__main__":

--- a/test/srt/cpu/test_store_cache.py
+++ b/test/srt/cpu/test_store_cache.py
@@ -1,0 +1,252 @@
+import itertools
+import unittest
+
+import torch
+
+from sglang.srt.layers.quantization.fp8_kernel import is_fp8_fnuz
+from sglang.test.test_utils import CustomTestCase
+
+torch.manual_seed(42)
+
+fp8_dtype = torch.float8_e4m3fnuz if is_fp8_fnuz() else torch.float8_e4m3fn
+
+# Reference implementation (from index_buf_accessor_v4.py)
+def _set_k_and_s_torch(buf, loc, k_nope, k_rope, scale_k_nope, page_size):
+    num_pages, buf_numel_per_page = buf.shape
+    (num_tokens_to_write,) = loc.shape
+
+    nope_dim = k_nope.shape[1]
+    rope_dim = k_rope.shape[1]
+    scale_dim = scale_k_nope.shape[1]
+
+    buf_fp8 = buf.view(fp8_dtype).flatten()
+    buf_bf16 = buf.view(torch.bfloat16).flatten()
+    buf_scale = buf.view(torch.uint8).flatten()
+
+    loc_page_index = loc // page_size
+    loc_token_offset_in_page = loc % page_size
+
+    s_offset_nbytes_in_page = page_size * (nope_dim + rope_dim * 2)
+
+    nope_offset = loc_page_index * buf_numel_per_page + loc_token_offset_in_page * (
+        nope_dim + rope_dim * 2
+    )
+
+    rope_offset = (
+        loc_page_index * buf_numel_per_page // 2
+        + (loc_token_offset_in_page * (nope_dim + rope_dim * 2) + nope_dim) // 2
+    )
+
+    s_offset = (
+        loc_page_index * buf_numel_per_page
+        + s_offset_nbytes_in_page
+        + loc_token_offset_in_page * (scale_dim + 1)
+    )
+
+    for i in range(num_tokens_to_write):
+        buf_fp8[nope_offset[i] : nope_offset[i] + nope_dim] = k_nope[i]
+        buf_bf16[rope_offset[i] : rope_offset[i] + rope_dim] = k_rope[i]
+        buf_scale[s_offset[i] : s_offset[i] + scale_dim] = scale_k_nope[i]
+
+
+def make_test_data(num_pages, page_size, num_tokens, nope_dim=448, rope_dim=64, scale_dim=7):
+    """Create test data matching the buffer layout."""
+    nope_rope_bytes_per_token = nope_dim + rope_dim * 2
+    s_bytes_per_token = scale_dim + 1
+    buf_numel_per_page = page_size * nope_rope_bytes_per_token + page_size * s_bytes_per_token
+
+    buf = torch.zeros(num_pages, buf_numel_per_page, dtype=torch.uint8)
+
+    # Generate random non-overlapping locations
+    total_slots = num_pages * page_size
+    assert num_tokens <= total_slots
+    perm = torch.randperm(total_slots)[:num_tokens]
+    loc = perm.to(torch.int64)
+
+    k_nope = torch.randint(0, 256, (num_tokens, nope_dim), dtype=torch.uint8).view(fp8_dtype)
+    k_rope = torch.randn(num_tokens, rope_dim, dtype=torch.bfloat16)
+    scale_k_nope = torch.randint(0, 256, (num_tokens, scale_dim), dtype=torch.uint8)
+
+    return buf, loc, k_nope, k_rope, scale_k_nope
+
+
+class TestSetKAndS(CustomTestCase):
+    num_pages_list = [4, 16]
+    page_size_list = [1, 16]
+    num_tokens_list = [1, 7, 32]
+
+    def _test_set_k_and_s(self, num_pages, page_size, num_tokens):
+        max_tokens = num_pages * page_size
+        if num_tokens > max_tokens:
+            num_tokens = max_tokens
+
+        buf, loc, k_nope, k_rope, scale_k_nope = make_test_data(
+            num_pages, page_size, num_tokens
+        )
+
+        # Reference
+        buf_ref = buf.clone()
+        _set_k_and_s_torch(buf_ref, loc, k_nope, k_rope, scale_k_nope, page_size)
+
+        # C++ kernel
+        buf_test = buf.clone()
+        torch.ops.sgl_kernel.set_k_and_s_cpu(
+            buf_test, loc, k_nope, k_rope, scale_k_nope, page_size
+        )
+
+        torch.testing.assert_close(buf_ref, buf_test)
+
+    def test_set_k_and_s(self):
+        for params in itertools.product(
+            self.num_pages_list, self.page_size_list, self.num_tokens_list
+        ):
+            with self.subTest(
+                num_pages=params[0], page_size=params[1], num_tokens=params[2]
+            ):
+                self._test_set_k_and_s(*params)
+
+    def test_set_k_and_s_int32_loc(self):
+        """Test with int32 loc tensor."""
+        buf, loc, k_nope, k_rope, scale_k_nope = make_test_data(8, 16, 20)
+        loc_i32 = loc.to(torch.int32)
+
+        buf_ref = buf.clone()
+        _set_k_and_s_torch(buf_ref, loc, k_nope, k_rope, scale_k_nope, 16)
+
+        buf_test = buf.clone()
+        torch.ops.sgl_kernel.set_k_and_s_cpu(
+            buf_test, loc_i32, k_nope, k_rope, scale_k_nope, 16
+        )
+
+        torch.testing.assert_close(buf_ref, buf_test)
+
+    def test_set_k_and_s_large(self):
+        """Larger stress test."""
+        num_pages, page_size, num_tokens = 64, 16, 512
+        buf, loc, k_nope, k_rope, scale_k_nope = make_test_data(
+            num_pages, page_size, num_tokens
+        )
+
+        buf_ref = buf.clone()
+        _set_k_and_s_torch(buf_ref, loc, k_nope, k_rope, scale_k_nope, page_size)
+
+        buf_test = buf.clone()
+        torch.ops.sgl_kernel.set_k_and_s_cpu(
+            buf_test, loc, k_nope, k_rope, scale_k_nope, page_size
+        )
+
+        torch.testing.assert_close(buf_ref, buf_test)
+
+
+# ===========================================================================
+# Reference for quant_to_nope_fp8_rope_bf16_pack
+# ===========================================================================
+
+def _cast_scale_inv_to_ue8m0(scales_inv, out_dtype=torch.float32):
+    return torch.pow(2, torch.clamp_min(scales_inv, 1e-4).log2().ceil()).to(out_dtype)
+
+
+def quant_to_nope_fp8_rope_bf16_pack_ref(k_bf16):
+    """Reference implementation from quant_k_cache_v4.py."""
+    assert k_bf16.dtype == torch.bfloat16
+    _num_tokens, hidden_dim = k_bf16.shape
+    assert hidden_dim == 512
+    dim_nope = 448
+    dim_rope = 64
+
+    k_nope_bf16, k_rope_bf16 = k_bf16.split([dim_nope, dim_rope], dim=-1)
+
+    tile_size = 64
+    num_tiles = dim_nope // tile_size
+
+    x = k_nope_bf16.contiguous().view(-1, num_tiles, tile_size)
+    scale = x.abs().amax(dim=-1).float() / 448.0
+    scale_pow2_fp32 = _cast_scale_inv_to_ue8m0(scale, out_dtype=torch.float32)
+    scale_k_nope_ue8m0 = scale_pow2_fp32.to(torch.float8_e8m0fnu)
+    k_nope_fp8 = (x.float() / scale_pow2_fp32.unsqueeze(-1)).to(fp8_dtype)
+    k_nope_fp8 = k_nope_fp8.view(-1, tile_size * num_tiles)
+    scale_k_nope_ue8m0 = scale_k_nope_ue8m0.view(torch.uint8)
+
+    return k_nope_fp8, k_rope_bf16.contiguous(), scale_k_nope_ue8m0
+
+
+class TestQuantToNopeFp8RopeBf16Pack(CustomTestCase):
+    num_tokens_list = [1, 7, 32, 128, 512]
+
+    def _test_quant(self, num_tokens):
+        k_bf16 = torch.randn(num_tokens, 512, dtype=torch.bfloat16)
+
+        ref_nope, ref_rope, ref_scale = quant_to_nope_fp8_rope_bf16_pack_ref(k_bf16)
+        cpp_nope, cpp_rope, cpp_scale = (
+            torch.ops.sgl_kernel.quant_to_nope_fp8_rope_bf16_pack_cpu(k_bf16)
+        )
+
+        torch.testing.assert_close(ref_rope, cpp_rope)
+        torch.testing.assert_close(ref_scale, cpp_scale)
+        torch.testing.assert_close(
+            ref_nope.view(torch.uint8), cpp_nope.view(torch.uint8)
+        )
+
+    def test_quant_various_sizes(self):
+        for num_tokens in self.num_tokens_list:
+            with self.subTest(num_tokens=num_tokens):
+                self._test_quant(num_tokens)
+
+    def test_quant_small_values(self):
+        """Test with very small values that exercise the EPS clamp."""
+        k_bf16 = torch.randn(16, 512, dtype=torch.bfloat16) * 1e-6
+        ref_nope, ref_rope, ref_scale = quant_to_nope_fp8_rope_bf16_pack_ref(k_bf16)
+        cpp_nope, cpp_rope, cpp_scale = (
+            torch.ops.sgl_kernel.quant_to_nope_fp8_rope_bf16_pack_cpu(k_bf16)
+        )
+        torch.testing.assert_close(ref_rope, cpp_rope)
+        torch.testing.assert_close(ref_scale, cpp_scale)
+        torch.testing.assert_close(
+            ref_nope.view(torch.uint8), cpp_nope.view(torch.uint8)
+        )
+
+    def test_quant_large_values(self):
+        """Test with large values."""
+        k_bf16 = torch.randn(16, 512, dtype=torch.bfloat16) * 100.0
+        ref_nope, ref_rope, ref_scale = quant_to_nope_fp8_rope_bf16_pack_ref(k_bf16)
+        cpp_nope, cpp_rope, cpp_scale = (
+            torch.ops.sgl_kernel.quant_to_nope_fp8_rope_bf16_pack_cpu(k_bf16)
+        )
+        torch.testing.assert_close(ref_rope, cpp_rope)
+        torch.testing.assert_close(ref_scale, cpp_scale)
+        torch.testing.assert_close(
+            ref_nope.view(torch.uint8), cpp_nope.view(torch.uint8)
+        )
+
+    def test_quant_zeros(self):
+        """Test with zero input."""
+        k_bf16 = torch.zeros(8, 512, dtype=torch.bfloat16)
+        ref_nope, ref_rope, ref_scale = quant_to_nope_fp8_rope_bf16_pack_ref(k_bf16)
+        cpp_nope, cpp_rope, cpp_scale = (
+            torch.ops.sgl_kernel.quant_to_nope_fp8_rope_bf16_pack_cpu(k_bf16)
+        )
+        torch.testing.assert_close(ref_rope, cpp_rope)
+        torch.testing.assert_close(ref_scale, cpp_scale)
+        torch.testing.assert_close(
+            ref_nope.view(torch.uint8), cpp_nope.view(torch.uint8)
+        )
+
+    def test_output_shapes_and_dtypes(self):
+        """Verify output shapes and dtypes."""
+        num_tokens = 16
+        k_bf16 = torch.randn(num_tokens, 512, dtype=torch.bfloat16)
+        cpp_nope, cpp_rope, cpp_scale = (
+            torch.ops.sgl_kernel.quant_to_nope_fp8_rope_bf16_pack_cpu(k_bf16)
+        )
+
+        self.assertEqual(cpp_nope.shape, (num_tokens, 448))
+        self.assertEqual(cpp_rope.shape, (num_tokens, 64))
+        self.assertEqual(cpp_scale.shape, (num_tokens, 7))
+
+        self.assertEqual(cpp_nope.dtype, fp8_dtype)
+        self.assertEqual(cpp_rope.dtype, torch.bfloat16)
+        self.assertEqual(cpp_scale.dtype, torch.uint8)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/srt/cpu/test_store_cache.py
+++ b/test/srt/cpu/test_store_cache.py
@@ -248,5 +248,128 @@ class TestQuantToNopeFp8RopeBf16Pack(CustomTestCase):
         self.assertEqual(cpp_scale.dtype, torch.uint8)
 
 
+# ===========================================================================
+# Reference for set_s (from index_buf_accessor.py SetS.torch_fast)
+# ===========================================================================
+
+def _set_s_torch(buf, loc, index_k_scale, page_size, index_head_dim):
+    """Reference implementation matching SetS.torch_fast."""
+    (num_tokens_to_write,) = loc.shape
+    buf_numel_per_page = buf.shape[1]
+    num_s_bytes_per_token = 4
+    s_offset_in_page = page_size * index_head_dim
+
+    loc_page_index = loc // page_size
+    loc_token_offset_in_page = loc % page_size
+
+    flat_buf = buf.flatten()
+    flat_indices = (
+        (loc_page_index * buf_numel_per_page)[:, None]
+        + s_offset_in_page
+        + (loc_token_offset_in_page * num_s_bytes_per_token)[:, None]
+        + torch.arange(num_s_bytes_per_token, dtype=torch.int32, device="cpu")[None, :]
+    )
+    number_s_bytes_total = num_tokens_to_write * num_s_bytes_per_token
+    flat_indices = flat_indices.flatten()[:number_s_bytes_total]
+    flat_buf[flat_indices] = index_k_scale.view(torch.uint8).flatten()
+
+
+def make_set_s_test_data(num_pages, page_size, num_tokens, index_head_dim=128):
+    """Create test data for set_s_cpu."""
+    buf_numel_per_page = page_size * index_head_dim + page_size * 4
+    buf = torch.zeros(num_pages, buf_numel_per_page, dtype=torch.uint8)
+
+    total_slots = num_pages * page_size
+    assert num_tokens <= total_slots
+    perm = torch.randperm(total_slots)[:num_tokens]
+    loc = perm.to(torch.int64)
+
+    index_k_scale = torch.randn(num_tokens, dtype=torch.float32)
+
+    return buf, loc, index_k_scale
+
+
+class TestSetS(CustomTestCase):
+    num_pages_list = [4, 16]
+    page_size_list = [1, 16, 64]
+    num_tokens_list = [1, 7, 32]
+
+    def _test_set_s(self, num_pages, page_size, num_tokens, index_head_dim=128):
+        max_tokens = num_pages * page_size
+        if num_tokens > max_tokens:
+            num_tokens = max_tokens
+
+        buf, loc, index_k_scale = make_set_s_test_data(
+            num_pages, page_size, num_tokens, index_head_dim
+        )
+
+        # Reference
+        buf_ref = buf.clone()
+        _set_s_torch(buf_ref, loc, index_k_scale, page_size, index_head_dim)
+
+        # C++ kernel
+        buf_test = buf.clone()
+        torch.ops.sgl_kernel.set_s_cpu(
+            buf_test, loc, index_k_scale, page_size, index_head_dim
+        )
+
+        torch.testing.assert_close(buf_ref, buf_test)
+
+    def test_set_s(self):
+        for params in itertools.product(
+            self.num_pages_list, self.page_size_list, self.num_tokens_list
+        ):
+            with self.subTest(
+                num_pages=params[0], page_size=params[1], num_tokens=params[2]
+            ):
+                self._test_set_s(*params)
+
+    def test_set_s_int32_loc(self):
+        """Test with int32 loc tensor."""
+        buf, loc, index_k_scale = make_set_s_test_data(8, 64, 20)
+        loc_i32 = loc.to(torch.int32)
+
+        buf_ref = buf.clone()
+        _set_s_torch(buf_ref, loc, index_k_scale, 64, 128)
+
+        buf_test = buf.clone()
+        torch.ops.sgl_kernel.set_s_cpu(buf_test, loc_i32, index_k_scale, 64, 128)
+
+        torch.testing.assert_close(buf_ref, buf_test)
+
+    def test_set_s_large(self):
+        """Larger stress test."""
+        num_pages, page_size, num_tokens = 64, 64, 2048
+        buf, loc, index_k_scale = make_set_s_test_data(
+            num_pages, page_size, num_tokens
+        )
+
+        buf_ref = buf.clone()
+        _set_s_torch(buf_ref, loc, index_k_scale, page_size, 128)
+
+        buf_test = buf.clone()
+        torch.ops.sgl_kernel.set_s_cpu(buf_test, loc, index_k_scale, page_size, 128)
+
+        torch.testing.assert_close(buf_ref, buf_test)
+
+    def test_set_s_2d_scale(self):
+        """Test with 2D scale tensor (num_tokens, 1)."""
+        num_pages, page_size, num_tokens = 8, 64, 20
+        buf_numel_per_page = page_size * 128 + page_size * 4
+        buf = torch.zeros(num_pages, buf_numel_per_page, dtype=torch.uint8)
+        total_slots = num_pages * page_size
+        perm = torch.randperm(total_slots)[:num_tokens]
+        loc = perm.to(torch.int64)
+        index_k_scale = torch.randn(num_tokens, 1, dtype=torch.float32)
+
+        buf_ref = buf.clone()
+        _set_s_torch(buf_ref, loc, index_k_scale.squeeze(1), page_size, 128)
+
+        buf_test = buf.clone()
+        torch.ops.sgl_kernel.set_s_cpu(buf_test, loc, index_k_scale, page_size, 128)
+
+        torch.testing.assert_close(buf_ref, buf_test)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/test/srt/cpu/test_store_cache.py
+++ b/test/srt/cpu/test_store_cache.py
@@ -249,6 +249,109 @@ class TestQuantToNopeFp8RopeBf16Pack(CustomTestCase):
 
 
 # ===========================================================================
+# Reference for set_k (from index_buf_accessor.py SetK.torch_fast)
+# ===========================================================================
+
+def _set_k_torch(buf, loc, index_k, page_size, index_head_dim):
+    """Reference implementation matching SetK.torch_fast."""
+    (num_tokens_to_write,) = loc.shape
+    buf_numel_per_page = buf.shape[1]
+    num_k_bytes_per_token = index_head_dim
+
+    loc_page_index = loc // page_size
+    loc_token_offset_in_page = loc % page_size
+
+    flat_buf = buf.flatten()
+    flat_indices = (
+        (loc_page_index * buf_numel_per_page)[:, None]
+        + (loc_token_offset_in_page * num_k_bytes_per_token)[:, None]
+        + torch.arange(num_k_bytes_per_token, dtype=torch.int32, device="cpu")[None, :]
+    )
+    num_k_bytes_total = num_tokens_to_write * num_k_bytes_per_token
+    flat_indices = flat_indices.flatten()[:num_k_bytes_total]
+    flat_buf[flat_indices] = index_k.view(torch.uint8).flatten()
+
+
+def make_set_k_test_data(num_pages, page_size, num_tokens, index_head_dim=128):
+    """Create test data for set_k_cpu."""
+    buf_numel_per_page = page_size * index_head_dim + page_size * 4
+    buf = torch.zeros(num_pages, buf_numel_per_page, dtype=torch.uint8)
+
+    total_slots = num_pages * page_size
+    assert num_tokens <= total_slots
+    perm = torch.randperm(total_slots)[:num_tokens]
+    loc = perm.to(torch.int64)
+
+    index_k = torch.randint(0, 256, (num_tokens, index_head_dim), dtype=torch.uint8).view(fp8_dtype)
+
+    return buf, loc, index_k
+
+
+class TestSetK(CustomTestCase):
+    num_pages_list = [4, 16]
+    page_size_list = [1, 16, 64]
+    num_tokens_list = [1, 7, 32]
+
+    def _test_set_k(self, num_pages, page_size, num_tokens, index_head_dim=128):
+        max_tokens = num_pages * page_size
+        if num_tokens > max_tokens:
+            num_tokens = max_tokens
+
+        buf, loc, index_k = make_set_k_test_data(
+            num_pages, page_size, num_tokens, index_head_dim
+        )
+
+        # Reference
+        buf_ref = buf.clone()
+        _set_k_torch(buf_ref, loc, index_k, page_size, index_head_dim)
+
+        # C++ kernel
+        buf_test = buf.clone()
+        torch.ops.sgl_kernel.set_k_cpu(
+            buf_test, loc, index_k, page_size, index_head_dim
+        )
+
+        torch.testing.assert_close(buf_ref, buf_test)
+
+    def test_set_k(self):
+        for params in itertools.product(
+            self.num_pages_list, self.page_size_list, self.num_tokens_list
+        ):
+            with self.subTest(
+                num_pages=params[0], page_size=params[1], num_tokens=params[2]
+            ):
+                self._test_set_k(*params)
+
+    def test_set_k_int32_loc(self):
+        """Test with int32 loc tensor."""
+        buf, loc, index_k = make_set_k_test_data(8, 64, 20)
+        loc_i32 = loc.to(torch.int32)
+
+        buf_ref = buf.clone()
+        _set_k_torch(buf_ref, loc, index_k, 64, 128)
+
+        buf_test = buf.clone()
+        torch.ops.sgl_kernel.set_k_cpu(buf_test, loc_i32, index_k, 64, 128)
+
+        torch.testing.assert_close(buf_ref, buf_test)
+
+    def test_set_k_large(self):
+        """Larger stress test."""
+        num_pages, page_size, num_tokens = 64, 64, 2048
+        buf, loc, index_k = make_set_k_test_data(
+            num_pages, page_size, num_tokens
+        )
+
+        buf_ref = buf.clone()
+        _set_k_torch(buf_ref, loc, index_k, page_size, 128)
+
+        buf_test = buf.clone()
+        torch.ops.sgl_kernel.set_k_cpu(buf_test, loc, index_k, page_size, 128)
+
+        torch.testing.assert_close(buf_ref, buf_test)
+
+
+# ===========================================================================
 # Reference for set_s (from index_buf_accessor.py SetS.torch_fast)
 # ===========================================================================
 

--- a/test/srt/cpu/test_topk.py
+++ b/test/srt/cpu/test_topk.py
@@ -1,9 +1,14 @@
 import unittest
 
 import torch
-
+from typing import Optional
 from sglang.srt.layers.moe.topk import (
+    _mask_topk_ids_padded_region,
     biased_grouped_topk_impl as native_biased_grouped_topk,
+)
+from sglang.srt.eplb.expert_location_dispatch import (
+    ExpertLocationDispatchInfo,
+    topk_ids_logical_to_physical,
 )
 from sglang.srt.layers.moe.topk import fused_topk_torch_native as native_fused_topk
 from sglang.srt.layers.moe.topk import grouped_topk_gpu as native_grouped_topk
@@ -11,6 +16,67 @@ from sglang.srt.models.llama4 import Llama4MoE
 from sglang.test.test_utils import CustomTestCase
 
 torch.manual_seed(1234)
+
+
+def native_biased_topk(
+    hidden_states: torch.Tensor,
+    gating_output: torch.Tensor,
+    correction_bias: torch.Tensor,
+    topk: int,
+    renormalize: bool,
+    scoring_func: str = "sigmoid",
+    num_fused_shared_experts: int = 0,
+    routed_scaling_factor: Optional[float] = None,
+    num_token_non_padded: Optional[torch.Tensor] = None,
+    expert_location_dispatch_info: Optional[ExpertLocationDispatchInfo] = None,
+    apply_routed_scaling_factor_on_output: Optional[bool] = False,
+):
+    assert hidden_states.shape[0] == gating_output.shape[0], "Number of tokens mismatch"
+
+    if scoring_func == "sigmoid":
+        scores = gating_output.sigmoid()
+    elif scoring_func == "sqrtsoftplus":
+        scores = torch.nn.functional.softplus(gating_output).sqrt()
+
+    num_token = scores.shape[0]
+    num_experts = scores.shape[1]
+
+    scores_for_choice = scores.view(num_token, -1) + correction_bias.unsqueeze(0)
+    _, topk_ids = torch.topk(
+        scores_for_choice,
+        k=topk,
+        dim=-1,
+        sorted=(True if num_fused_shared_experts > 0 else False),
+    )
+    topk_weights = scores.gather(1, topk_ids)
+
+    if num_fused_shared_experts:
+        topk_ids[:, -1] = torch.randint(
+            low=num_experts,
+            high=num_experts + num_fused_shared_experts,
+            size=(topk_ids.size(0),),
+            dtype=topk_ids.dtype,
+            device=topk_ids.device,
+        )
+        if routed_scaling_factor is not None:
+            topk_weights[:, -1] = (
+                topk_weights[:, :-1].sum(dim=-1) / routed_scaling_factor
+            )
+
+    if renormalize:
+        topk_weights_sum = (
+            topk_weights.sum(dim=-1, keepdim=True)
+            if num_fused_shared_experts == 0
+            else topk_weights[:, :-1].sum(dim=-1, keepdim=True)
+        )
+        topk_weights = topk_weights / topk_weights_sum
+        if apply_routed_scaling_factor_on_output:
+            topk_weights *= routed_scaling_factor
+
+    topk_weights, topk_ids = topk_weights.to(torch.float32), topk_ids.to(torch.int32)
+    topk_ids = topk_ids_logical_to_physical(topk_ids, expert_location_dispatch_info)
+    _mask_topk_ids_padded_region(topk_ids, num_token_non_padded)
+    return topk_weights, topk_ids
 
 
 # This is used by the Deepseek-V2 model
@@ -214,6 +280,227 @@ class TestCustomTopK(CustomTestCase):
             self._run_single_test(
                 123, 32, 1, False, torch.bfloat16, native_custom_f, fused_custom_f
             )
+
+
+# biased topk (flat, non-grouped) for DeepSeek V4
+class TestBiasedTopK(CustomTestCase):
+    def _run_single_test(
+        self,
+        M,
+        E,
+        topk,
+        renormalize,
+        gating_dtype,
+        bias_dtype,
+        scoring_func,
+        num_fused_shared_experts=0,
+        routed_scaling_factor=None,
+    ):
+        torch.manual_seed(2024)
+
+        hidden_states = torch.randn(M, 100, dtype=torch.bfloat16)
+        gating_output = torch.randn(M, E, dtype=gating_dtype) * 2 * M
+        correction_bias = torch.randn(E, dtype=bias_dtype)
+
+        ref_topk_weights, ref_topk_ids = native_biased_topk(
+            hidden_states.float(),
+            gating_output.float(),
+            correction_bias.float(),
+            topk,
+            renormalize,
+            scoring_func=scoring_func,
+            num_fused_shared_experts=0,
+            routed_scaling_factor=None,
+        )
+
+        # fused version - use float32 inputs for consistent comparison
+        gating_float = gating_output.float()
+        bias_float = correction_bias.float()
+        topk_weights, topk_ids = torch.ops.sgl_kernel.biased_topk_cpu(
+            hidden_states,
+            gating_float,
+            bias_float,
+            topk,
+            renormalize,
+            scoring_func,
+            0,  # num_fused_shared_experts
+            None,  # routed_scaling_factor
+            False,  # apply_routed_scaling_factor_on_output
+        )
+
+        # Ties in biased scores can cause different expert selections between
+        # torch.topk and std::partial_sort, both are valid.
+        # We verify correctness by checking that all selected experts have biased
+        # scores >= all unselected experts (within tolerance).
+        gating_float = gating_output.float()
+        bias_float = correction_bias.float()
+        if scoring_func == "sigmoid":
+            scores = gating_float.sigmoid()
+        else:
+            scores = torch.nn.functional.softplus(gating_float).sqrt()
+        scores_biased = scores + bias_float.unsqueeze(0)
+
+        for i in range(M):
+            selected = topk_ids[i].long()
+            min_selected = scores_biased[i].gather(0, selected).min().item()
+            mask = torch.ones(E, dtype=torch.bool)
+            mask[selected] = False
+            if mask.any():
+                max_unselected = scores_biased[i][mask].max().item()
+                self.assertLessEqual(max_unselected, min_selected + 1e-5)
+
+        # For rows where the same experts are selected, weights should match
+        for i in range(M):
+            ref_set = set(ref_topk_ids[i].tolist())
+            fused_set = set(topk_ids[i].tolist())
+            if ref_set == fused_set:
+                # Same experts selected, compare weights via scatter
+                res_row = torch.zeros(E, dtype=torch.float)
+                ref_row = torch.zeros(E, dtype=torch.float)
+                res_row.scatter_(0, topk_ids[i].long(), topk_weights[i])
+                ref_row.scatter_(0, ref_topk_ids[i].long(), ref_topk_weights[i])
+                torch.testing.assert_close(res_row, ref_row, atol=1e-5, rtol=1e-4)
+
+    def test_biased_topk_sigmoid(self):
+        for renormalize in [True, False]:
+            for bias_dtype in [torch.float32, torch.bfloat16]:
+                for gating_dtype in [torch.float32, torch.bfloat16]:
+                    for E in [64, 128, 256]:
+                        self._run_single_test(
+                            34, E, 8, renormalize, gating_dtype, bias_dtype, "sigmoid"
+                        )
+
+    def test_biased_topk_sqrtsoftplus(self):
+        for renormalize in [True, False]:
+            for bias_dtype in [torch.float32, torch.bfloat16]:
+                for gating_dtype in [torch.float32, torch.bfloat16]:
+                    for E in [64, 128, 256]:
+                        self._run_single_test(
+                            34,
+                            E,
+                            8,
+                            renormalize,
+                            gating_dtype,
+                            bias_dtype,
+                            "sqrtsoftplus",
+                        )
+
+
+def hash_topk_native(
+    gating_output,
+    tid2eid,
+    topk,
+    scoring_func,
+    num_fused_shared_experts,
+    routed_scaling_factor,
+):
+    M = gating_output.size(0)
+    g = gating_output.float()
+    if scoring_func == "softmax":
+        scores = g.softmax(dim=-1)
+    elif scoring_func == "sigmoid":
+        scores = g.sigmoid()
+    else:
+        scores = torch.nn.functional.softplus(g).sqrt()
+
+    topk_ids = torch.zeros(M, topk, dtype=torch.int32)
+    topk_weights = torch.zeros(M, topk, dtype=torch.float32)
+
+    if num_fused_shared_experts == 1:
+        topk_ids[:, :-1] = tid2eid
+        topk_weights[:, :-1] = scores.gather(1, tid2eid.long())
+        if scoring_func != "softmax":
+            topk_weights[:, :-1] /= topk_weights[:, :-1].sum(dim=-1, keepdim=True)
+        # shared expert weight = sum of routed weights / scaling_factor
+        topk_weights[:, -1] = topk_weights[:, :-1].sum(dim=-1) / routed_scaling_factor
+    else:
+        topk_ids[:, :] = tid2eid
+        topk_weights[:, :] = scores.gather(1, tid2eid.long())
+        if scoring_func != "softmax":
+            topk_weights[:, :] /= topk_weights[:, :].sum(dim=-1, keepdim=True)
+
+    return topk_weights, topk_ids
+
+
+# HashTopK for DeepSeek V4 (expert IDs from precomputed lookup table)
+class TestHashTopK(CustomTestCase):
+    def _run_single_test(
+        self,
+        M,
+        E,
+        topk,
+        scoring_func,
+        num_fused_shared_experts,
+        routed_scaling_factor,
+        gating_dtype,
+    ):
+        torch.manual_seed(2026)
+
+        routed_topk = topk - num_fused_shared_experts
+        # Simulate tid2eid: random expert assignments for each token
+        tid2eid = torch.randint(0, E, (M, routed_topk), dtype=torch.int32)
+        gating_output = torch.randn(M, E, dtype=gating_dtype) * 2 * M
+
+        ref_topk_weights, ref_topk_ids = hash_topk_native(
+            gating_output,
+            tid2eid,
+            topk,
+            scoring_func,
+            num_fused_shared_experts,
+            routed_scaling_factor,
+        )
+
+        # Fused kernel
+        fused_w, fused_ids = torch.ops.sgl_kernel.hash_topk_cpu(
+            gating_output,
+            tid2eid,
+            topk,
+            scoring_func,
+            num_fused_shared_experts,
+            E,
+            routed_scaling_factor,
+        )
+
+        # Compare routed expert IDs (all slots for no-fused, or :-1 for fused)
+        if num_fused_shared_experts == 1:
+            torch.testing.assert_close(
+                fused_ids[:, :-1], ref_topk_ids[:, :-1], atol=0, rtol=0
+            )
+            # Shared expert ID should be in [E, E + num_fused_shared_experts)
+            self.assertTrue((fused_ids[:, -1] >= E).all())
+            self.assertTrue((fused_ids[:, -1] < E + num_fused_shared_experts).all())
+            # Compare routed weights (use allclose to avoid NaN relative diff from underflow)
+            self.assertTrue(
+                torch.allclose(
+                    fused_w[:, :-1], ref_topk_weights[:, :-1], atol=2e-4, rtol=0
+                ),
+                f"routed weights mismatch: max abs diff = {(fused_w[:, :-1] - ref_topk_weights[:, :-1]).abs().max()}",
+            )
+            # Compare shared expert weights
+            self.assertTrue(
+                torch.allclose(
+                    fused_w[:, -1], ref_topk_weights[:, -1], atol=2e-4, rtol=0
+                ),
+                f"shared weights mismatch: max abs diff = {(fused_w[:, -1] - ref_topk_weights[:, -1]).abs().max()}",
+            )
+        else:
+            torch.testing.assert_close(fused_ids, ref_topk_ids, atol=0, rtol=0)
+            self.assertTrue(
+                torch.allclose(fused_w, ref_topk_weights, atol=2e-4, rtol=0),
+                f"weights mismatch: max abs diff = {(fused_w - ref_topk_weights).abs().max()}",
+            )
+
+    def test_hash_topk_no_fused(self):
+        for scoring_func in ["softmax", "sigmoid", "sqrtsoftplus"]:
+            for gating_dtype in [torch.float32, torch.bfloat16]:
+                for E in [64, 128, 256]:
+                    self._run_single_test(34, E, 8, scoring_func, 0, 1.5, gating_dtype)
+
+    def test_hash_topk_with_fused(self):
+        for scoring_func in ["sigmoid", "sqrtsoftplus"]:
+            for gating_dtype in [torch.float32, torch.bfloat16]:
+                for E in [64, 128, 256]:
+                    self._run_single_test(34, E, 8, scoring_func, 1, 1.5, gating_dtype)
 
 
 if __name__ == "__main__":

--- a/test/srt/cpu/utils.py
+++ b/test/srt/cpu/utils.py
@@ -221,6 +221,106 @@ def torch_naive_fused_moe(a, w1, w2, score, topk, renormalize):
     ).sum(dim=1)
 
 
+def moe_gptoss_act(x, alpha: float = 1.702, limit: float = 7.0):
+    x_glu, x_linear = x[..., ::2], x[..., 1::2]
+    # Clamp the input values
+    x_glu = x_glu.clamp(min=None, max=limit)
+    x_linear = x_linear.clamp(min=-limit, max=limit)
+    out_glu = x_glu * torch.sigmoid(alpha * x_glu)
+    # Note we add an extra bias of 1 to the linear layer
+    return out_glu * (x_linear + 1.0)
+
+
+def torch_naive_gptoss_fused_moe(
+    x,
+    w1,
+    w2,
+    w1_bias,
+    w2_bias,
+    topk_weights,
+    topk_ids,
+    activation_alpha,
+    swiglu_limit,
+    len_experts,
+) -> torch.Tensor:
+
+    # Ref code from https://huggingface.co/deepseek-ai/DeepSeek-V2/blob/e0828e3cc0a03408724b80c3cc92c8e072db8d01/modeling_deepseek.py#L589
+    cnts = topk_ids.new_zeros((topk_ids.shape[0], len_experts))
+    cnts.scatter_(1, topk_ids.to(torch.int64), 1)
+    tokens_per_expert = cnts.sum(dim=0)
+    idxs = topk_ids.view(-1).argsort()
+
+    sorted_tokens = x[idxs // topk_ids.shape[1]]
+    tokens_per_expert = tokens_per_expert.cpu().numpy()
+
+    outputs = []
+    start_idx = 0
+    for i, num_tokens in enumerate(tokens_per_expert):
+        end_idx = start_idx + num_tokens
+        if num_tokens == 0:
+            continue
+        tokens_for_this_expert = sorted_tokens[start_idx:end_idx]
+
+        layer_w13_weight = w1[i]
+        layer_w13_weight_bias = w1_bias[i]
+        layer_w2_weight_bias = w2_bias[i]
+        layer_w2_weight = w2[i]
+
+        gate_up = F.linear(
+            tokens_for_this_expert,
+            layer_w13_weight,
+            bias=layer_w13_weight_bias.to(torch.bfloat16),
+        )
+        gate_up = moe_gptoss_act(gate_up, activation_alpha, swiglu_limit)
+        expert_out = F.linear(
+            gate_up, layer_w2_weight, bias=layer_w2_weight_bias.to(torch.bfloat16)
+        )
+        outputs.append(expert_out)
+        start_idx = end_idx
+
+    outs = torch.cat(outputs, dim=0) if len(outputs) else sorted_tokens.new_empty(0)
+    new_x = torch.empty_like(outs)
+
+    new_x[idxs] = outs
+    final_out = (
+        new_x.view(*topk_ids.shape, -1)
+        .type(topk_weights.dtype)
+        .mul_(topk_weights.unsqueeze(dim=-1))
+        .sum(dim=1)
+        .type(new_x.dtype)
+    )
+    return final_out
+
+
+def torch_naive_fused_moe_gptoss(
+    a,
+    w1,
+    w2,
+    w1_bias,
+    w2_bias,
+    topk_weight,
+    topk_ids,
+    renormalize,
+    activation_alpha,
+    swiglu_limit,
+    len_experts,
+):
+    if renormalize:
+        topk_weight = topk_weight / topk_weight.sum(dim=-1, keepdim=True)
+
+    return torch_naive_gptoss_fused_moe(
+        a,
+        w1,
+        w2,
+        w1_bias,
+        w2_bias,
+        topk_weight,
+        topk_ids,
+        activation_alpha,
+        swiglu_limit,
+        len_experts,
+    )
+
 def torch_w8a8_per_column_fused_moe(a, w1, w2, w1_s, w2_s, topk_weight, topk_ids, topk):
     """This function performs fused moe with per-column int8 quantization using native torch."""
 
@@ -293,6 +393,119 @@ def native_fp8_fused_moe(a, w1, w2, topk_weight, topk_ids, topk):
         .to(a.dtype)
     )
 
+# https://github.com/NVIDIA/TensorRT-Model-Optimizer/blob/main/modelopt/torch/quantization/qtensor/mxfp4_tensor.py
+class MXFP4QuantizeUtil:
+    E2M1_max = 6.0
+
+    E2M1_values = [0, 0.5, 1, 1.5, 2, 3, 4, 6]
+    E2M1_bounds = torch.tensor([0.25, 0.75, 1.25, 1.75, 2.5, 3.5, 5])
+
+    block_size = 32
+
+    @classmethod
+    def quantize(cls, input: torch.Tensor) -> tuple:
+        """Converting a tensor to a quantized format based on MXFP4 quantization. Only E4M3 is supported.
+        Args:
+            input (torch.Tensor): The input tensor to be quantized.
+        """
+
+        def cast_fp4(x):
+            sign = torch.sign(x)
+            sign_bit = (2 - sign) // 2
+            ord_ = torch.sum(
+                (x.abs().unsqueeze(-1) - cls.E2M1_bounds.to(x.device)) > 0, dim=-1
+            )
+            fp4_val = (sign_bit * 0b1000 + ord_).to(torch.uint8)
+            return fp4_val
+
+        def fuse_uint4_to_uint8(x):
+            # If the last dimension is odd, pad with zeros
+            # If this behavior is not desired, please modify the code accordingly
+            left_side = x[..., 0::2]  # Even indices (0, 2, 4...)
+            right_side = x[..., 1::2]  # Odd indices (1, 3, 5...)
+            new_data = (
+                right_side.clone() << 4
+            )  # Put odd indices (higher addresses) in high bits
+            new_data[
+                ..., : left_side.shape[-1]
+            ] += left_side  # Put even indices in low bits
+            return new_data
+
+        original_shape = input.shape
+        original_dtype = input.dtype
+        input = input.view(-1, cls.block_size)
+        # get scales
+        input_amax = input.abs().max(dim=-1, keepdim=True).values
+        descale = input_amax / cls.E2M1_max
+        min_value = torch.tensor(-127.0, device=descale.device)
+        e8m0_scale = torch.ceil(torch.maximum(torch.log2(descale), min_value))
+
+        input = (input / torch.exp2(e8m0_scale)).view(original_shape)
+        input_q = cast_fp4(input)
+        input_q = fuse_uint4_to_uint8(input_q)
+        e8m0_scale = (e8m0_scale + 127).to(torch.uint8)
+        return input_q, e8m0_scale
+
+    @classmethod
+    def dequantize(cls, quantized_data, dtype: torch.dtype, scale):
+        """Dequantze MXFP4 packed tensor to a target dtype."""
+
+        def unfuse_uint8_to_uint4(x):
+            """Unfuse uint8 values back to uint4 values.
+            This is the inverse operation of fuse_uint4_to_uint8.
+            """
+            # Extract the lower 4 bits (even indices)
+            left_side = x & 0x0F
+
+            # Extract the upper 4 bits (odd indices)
+            right_side = (x >> 4) & 0x0F
+
+            # Create a new tensor with alternating values
+            shape = list(x.shape)
+            shape[-1] = shape[-1] * 2
+            result = torch.zeros(shape, dtype=torch.uint8, device=x.device)
+
+            # Fill in the values - even indices get low bits, odd indices get high bits
+            result[..., 0::2] = left_side  # Even indices from low bits
+            result[..., 1::2] = right_side  # Odd indices from high bits
+
+            return result
+
+        e8m0_scale = scale
+
+        # Unfuse the uint8 values back to uint4
+        x_unfused = unfuse_uint8_to_uint4(quantized_data)
+        # print("@@@ x_unfused: ", x_unfused)
+        # Extract sign and magnitude
+        sign = 1 - 2 * ((x_unfused & 0b1000) >> 3).to(
+            torch.float32
+        )  # Extract sign bit and convert to +1/-1
+        magnitude = x_unfused & 0b0111  # Extract magnitude bits
+        magnitude = magnitude.to(torch.long)
+
+        # Create a tensor with the E2M1 values
+        values = torch.tensor(cls.E2M1_values, device=quantized_data.device)
+
+        # Use gather to index the values tensor properly
+        # We need to reshape magnitude to match the dimensions we want to gather along
+        original_shape = magnitude.shape
+        x_float = values[magnitude.reshape(-1)].reshape(original_shape)
+
+        # Apply sign and scale
+        x_float = sign.float() * x_float
+
+        # Reshape to apply block-wise scaling
+        x_float = x_float.reshape(-1, cls.block_size)
+
+        # Apply the E8M0 scale
+        scale_factor = torch.exp2(e8m0_scale.float() - 127)
+        scale_factor = scale_factor.reshape(-1, 1)  # Reshape for proper broadcasting
+
+        # Apply scaling and reshape back to original shape
+        x_float = x_float * scale_factor
+
+        # Reshape back to the original shape
+        return x_float.reshape(original_shape).to(dtype)
 
 def make_non_contiguous(x: torch.Tensor) -> torch.Tensor:
     """

--- a/test/srt/cpu/utils.py
+++ b/test/srt/cpu/utils.py
@@ -38,6 +38,14 @@ def GeluAndMul(x: torch.Tensor, approximate="tanh") -> torch.Tensor:
     d = x.shape[-1] // 2
     return F.gelu(x[..., :d], approximate=approximate) * x[..., d:]
 
+# Reference: https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash/blob/fd53f944496234770ba80e15004f9b6d269a71f5/inference/model.py#L600-L603
+def ClampedSiluAndMul(x: torch.Tensor, limit: float) -> torch.Tensor:
+    """DSV4-2604B activation: clamp gate upper, clamp up symmetric, silu(gate)*up."""
+    d = x.shape[-1] // 2
+    gate = x[..., :d].clamp(max=limit)
+    up = x[..., d:].clamp(min=-limit, max=limit)
+    return F.silu(gate) * up
+
 
 def per_token_quant_int8(x):
     x = x.float()
@@ -372,6 +380,17 @@ def torch_w8a8_per_column_fused_moe(a, w1, w2, w1_s, w2_s, topk_weight, topk_ids
 
 
 def native_fp8_fused_moe(a, w1, w2, topk_weight, topk_ids, topk):
+    return _native_fused_moe_with_act(a, w1, w2, topk_weight, topk_ids, topk, SiluAndMul)
+
+
+def native_clamped_silu_fused_moe(a, w1, w2, topk_weight, topk_ids, topk, limit):
+    return _native_fused_moe_with_act(
+        a, w1, w2, topk_weight, topk_ids, topk,
+        lambda x: ClampedSiluAndMul(x, limit),
+    )
+
+
+def _native_fused_moe_with_act(a, w1, w2, topk_weight, topk_ids, topk, act_fn):
     B, D = a.shape
     a = a.view(B, -1, D).repeat(1, topk, 1).reshape(-1, D).float()
     out = torch.zeros(B * topk, w2.shape[1], dtype=torch.float32, device=a.device)
@@ -384,7 +403,7 @@ def native_fp8_fused_moe(a, w1, w2, topk_weight, topk_ids, topk):
         mask = topk_ids == i
         if mask.sum():
             ic0 = torch.matmul(a[mask], w1[i].transpose(0, 1))
-            ic1 = SiluAndMul(ic0)
+            ic1 = act_fn(ic0)
             out[mask] = torch.matmul(ic1, w2[i].transpose(0, 1))
 
     return (

--- a/test/srt/cpu/utils.py
+++ b/test/srt/cpu/utils.py
@@ -38,6 +38,7 @@ def GeluAndMul(x: torch.Tensor, approximate="tanh") -> torch.Tensor:
     d = x.shape[-1] // 2
     return F.gelu(x[..., :d], approximate=approximate) * x[..., d:]
 
+
 # Reference: https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash/blob/fd53f944496234770ba80e15004f9b6d269a71f5/inference/model.py#L600-L603
 def ClampedSiluAndMul(x: torch.Tensor, limit: float) -> torch.Tensor:
     """DSV4-2604B activation: clamp gate upper, clamp up symmetric, silu(gate)*up."""
@@ -134,7 +135,9 @@ def native_w8a8_per_token_matmul(A, B, As, Bs, bias, output_dtype=torch.bfloat16
     return C.reshape(origin_C_shape).to(output_dtype)
 
 
-def torch_naive_moe(a, w1, w2, b, routed_scaling_factor, output_dtype=torch.bfloat16):
+def _torch_naive_moe_with_act(
+    a, w1, w2, b, routed_scaling_factor, output_dtype=torch.bfloat16, act_fn=SiluAndMul
+):
 
     a = a.to(torch.float32)
     w1 = w1.to(torch.float32)
@@ -142,12 +145,32 @@ def torch_naive_moe(a, w1, w2, b, routed_scaling_factor, output_dtype=torch.bflo
     b = b.to(torch.float32) if b is not None else None
 
     ic1 = torch.matmul(a, w1.transpose(0, 1))
-    ic2 = SiluAndMul(ic1)
+    ic2 = act_fn(ic1)
     ic3 = torch.matmul(ic2, w2.transpose(0, 1))
 
     out = ic3 if b is None else ic3 + b * routed_scaling_factor
 
     return out.to(output_dtype)
+
+
+def torch_naive_moe(a, w1, w2, b, routed_scaling_factor, output_dtype=torch.bfloat16):
+    return _torch_naive_moe_with_act(
+        a, w1, w2, b, routed_scaling_factor, output_dtype, act_fn=SiluAndMul
+    )
+
+
+def torch_naive_clamped_silu_moe(
+    a, w1, w2, b, routed_scaling_factor, limit, output_dtype=torch.bfloat16
+):
+    return _torch_naive_moe_with_act(
+        a,
+        w1,
+        w2,
+        b,
+        routed_scaling_factor,
+        output_dtype,
+        act_fn=lambda x: ClampedSiluAndMul(x, limit),
+    )
 
 
 def torch_w8a8_per_column_moe(
@@ -329,6 +352,7 @@ def torch_naive_fused_moe_gptoss(
         len_experts,
     )
 
+
 def torch_w8a8_per_column_fused_moe(a, w1, w2, w1_s, w2_s, topk_weight, topk_ids, topk):
     """This function performs fused moe with per-column int8 quantization using native torch."""
 
@@ -380,12 +404,19 @@ def torch_w8a8_per_column_fused_moe(a, w1, w2, w1_s, w2_s, topk_weight, topk_ids
 
 
 def native_fp8_fused_moe(a, w1, w2, topk_weight, topk_ids, topk):
-    return _native_fused_moe_with_act(a, w1, w2, topk_weight, topk_ids, topk, SiluAndMul)
+    return _native_fused_moe_with_act(
+        a, w1, w2, topk_weight, topk_ids, topk, SiluAndMul
+    )
 
 
 def native_clamped_silu_fused_moe(a, w1, w2, topk_weight, topk_ids, topk, limit):
     return _native_fused_moe_with_act(
-        a, w1, w2, topk_weight, topk_ids, topk,
+        a,
+        w1,
+        w2,
+        topk_weight,
+        topk_ids,
+        topk,
         lambda x: ClampedSiluAndMul(x, limit),
     )
 
@@ -411,6 +442,7 @@ def _native_fused_moe_with_act(a, w1, w2, topk_weight, topk_ids, topk, act_fn):
         .sum(dim=1)
         .to(a.dtype)
     )
+
 
 # https://github.com/NVIDIA/TensorRT-Model-Optimizer/blob/main/modelopt/torch/quantization/qtensor/mxfp4_tensor.py
 class MXFP4QuantizeUtil:
@@ -525,6 +557,7 @@ class MXFP4QuantizeUtil:
 
         # Reshape back to the original shape
         return x_float.reshape(original_shape).to(dtype)
+
 
 def make_non_contiguous(x: torch.Tensor) -> torch.Tensor:
     """


### PR DESCRIPTION
- MXFP4 MOE with swiglu_limit
- Shared MOE with swiglu_limit
- topk: biased_topk_cpu, hash_topk_cpu
- Fix accuracy issue: replace einsum with bmm_cpu, enhance weight_packed_linear to support BF16 in FP32 out
- hadamard_transform_cpu
- store_cache: set_k_and_s_cpu, set_k_cpu, set_s_cpu
- alloc: alloc_decode_kernel_cpu, alloc_extend_kernel_cpu
- quant: act_quant_cpu, fused_scale_cpu, quant_to_nope_fp8_rope_bf16_pack_cpu 
- compressor: compress_decode_cpu