### PR TITLE
Refine the code by removing environment variables when launching tests on CPU.

### DIFF
--- a/python/sglang/jit_kernel/deepseek_v4.py
+++ b/python/sglang/jit_kernel/deepseek_v4.py
@@ -959,6 +959,8 @@ def linear_bf16_fp32(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
     from sglang.srt.environ import envs
 
     algo = envs.SGLANG_OPT_BF16_FP32_GEMM_ALGO.get()
+    if _is_cpu and _cpu_amx:
+        algo = "cpu_amx"
     return _dispatch_bf16_fp32_backend(x, y, algo=algo)
 
 

--- a/python/sglang/srt/layers/attention/deepseek_v4_backend.py
+++ b/python/sglang/srt/layers/attention/deepseek_v4_backend.py
@@ -907,23 +907,28 @@ class DeepseekV4AttnBackend(
         self, layer_id: int, swa_k: torch.Tensor, forward_batch: ForwardBatch
     ) -> None:
         raw_loc = forward_batch.out_cache_loc
-        if envs.SGLANG_OPT_USE_FUSED_STORE_CACHE.get():
+
+        if _is_cpu and _cpu_amx:
+            from sglang.srt.layers.attention.dsv4.index_buf_accessor import (
+                NopeFp8RopeBf16Pack,
+            )
+
+            swa_k_pack = NopeFp8RopeBf16Pack(
+                *torch.ops.sgl_kernel.quant_to_nope_fp8_rope_bf16_pack_cpu(swa_k)
+            )
+            self.token_to_kv_pool.set_swa_key_buffer_radix(
+                layer_id=layer_id,
+                raw_loc=raw_loc,
+                cache_nope_fp8_rope_bf16_pack=swa_k_pack,
+            )
+        elif envs.SGLANG_OPT_USE_FUSED_STORE_CACHE.get():
             self.token_to_kv_pool.set_swa_key_buffer_radix_fused(
                 layer_id=layer_id,
                 raw_loc=raw_loc,
                 cache_k=swa_k,
             )
         else:
-            if _is_cpu and _cpu_amx:
-                from sglang.srt.layers.attention.dsv4.index_buf_accessor import (
-                    NopeFp8RopeBf16Pack,
-                )
-
-                swa_k_pack = NopeFp8RopeBf16Pack(
-                    *torch.ops.sgl_kernel.quant_to_nope_fp8_rope_bf16_pack_cpu(swa_k)
-                )
-            else:
-                swa_k_pack = quant_to_nope_fp8_rope_bf16_pack_triton(swa_k)
+            swa_k_pack = quant_to_nope_fp8_rope_bf16_pack_triton(swa_k)
             self.token_to_kv_pool.set_swa_key_buffer_radix(
                 layer_id=layer_id,
                 raw_loc=raw_loc,

--- a/python/sglang/srt/layers/attention/dsv4/compressor.py
+++ b/python/sglang/srt/layers/attention/dsv4/compressor.py
@@ -388,7 +388,7 @@ class Compressor(nn.Module):
 
     @cached_property
     def use_fused_compress(self) -> bool:
-        if envs.SGLANG_CPU_USE_COMPRESS_SEPARATE.get():
+        if envs.SGLANG_CPU_USE_COMPRESS_SEPARATE.get() or (_is_cpu and _cpu_amx):
             return False
         return True
 

--- a/python/sglang/srt/layers/attention/dsv4/compressor.py
+++ b/python/sglang/srt/layers/attention/dsv4/compressor.py
@@ -171,9 +171,7 @@ class CompressorBackendMixin:
                 cache_k=new_compressed_kv,
             )
         else:
-            pack = quant_to_nope_fp8_rope_bf16_pack_triton(
-                new_compressed_kv.bfloat16()
-            )
+            pack = quant_to_nope_fp8_rope_bf16_pack_triton(new_compressed_kv.bfloat16())
             token_to_kv_pool.set_extra_key_buffer(layer_id, out_loc, pack)
 
     def forward_indexer_compressor(

--- a/python/sglang/srt/layers/attention/dsv4/compressor.py
+++ b/python/sglang/srt/layers/attention/dsv4/compressor.py
@@ -153,27 +153,27 @@ class CompressorBackendMixin:
             if compressor.ratio == 4
             else core_metadata.c128_out_loc
         )
-        if envs.SGLANG_OPT_USE_FUSED_STORE_CACHE.get():
+        if _is_cpu and _cpu_amx:
+            from sglang.srt.layers.attention.dsv4.index_buf_accessor import (
+                NopeFp8RopeBf16Pack,
+            )
+
+            pack = NopeFp8RopeBf16Pack(
+                *torch.ops.sgl_kernel.quant_to_nope_fp8_rope_bf16_pack_cpu(
+                    new_compressed_kv.bfloat16()
+                )
+            )
+            token_to_kv_pool.set_extra_key_buffer(layer_id, out_loc, pack)
+        elif envs.SGLANG_OPT_USE_FUSED_STORE_CACHE.get():
             token_to_kv_pool.set_extra_key_buffer_fused(
                 layer_id=layer_id,
                 loc=out_loc,
                 cache_k=new_compressed_kv,
             )
         else:
-            if _is_cpu and _cpu_amx:
-                from sglang.srt.layers.attention.dsv4.index_buf_accessor import (
-                    NopeFp8RopeBf16Pack,
-                )
-
-                pack = NopeFp8RopeBf16Pack(
-                    *torch.ops.sgl_kernel.quant_to_nope_fp8_rope_bf16_pack_cpu(
-                        new_compressed_kv.bfloat16()
-                    )
-                )
-            else:
-                pack = quant_to_nope_fp8_rope_bf16_pack_triton(
-                    new_compressed_kv.bfloat16()
-                )
+            pack = quant_to_nope_fp8_rope_bf16_pack_triton(
+                new_compressed_kv.bfloat16()
+            )
             token_to_kv_pool.set_extra_key_buffer(layer_id, out_loc, pack)
 
     def forward_indexer_compressor(
@@ -191,21 +191,27 @@ class CompressorBackendMixin:
             assert isinstance(token_to_kv_pool, DeepSeekV4TokenToKVPool)
 
         new_compressed_kv = compressor(x, forward_batch)
-        if envs.SGLANG_OPT_USE_FUSED_STORE_CACHE.get():
+
+        if _is_cpu and _cpu_amx:
+            new_compressed_kv_fp8, new_compressed_kv_scale = (
+                torch.ops.sgl_kernel.act_quant_cpu(new_compressed_kv)
+            )
+            token_to_kv_pool.set_index_k_scale_buffer(
+                layer_id=layer_id,
+                loc=self.forward_metadata.core_metadata.c4_out_loc,
+                index_k=new_compressed_kv_fp8,
+                index_k_scale=new_compressed_kv_scale,
+            )
+        elif envs.SGLANG_OPT_USE_FUSED_STORE_CACHE.get():
             token_to_kv_pool.set_index_k_fused(
                 layer_id=layer_id,
                 loc=self.forward_metadata.core_metadata.c4_out_loc,
                 cache_k=new_compressed_kv,
             )
         else:
-            if _is_cpu and _cpu_amx:
-                new_compressed_kv_fp8, new_compressed_kv_scale = (
-                    torch.ops.sgl_kernel.act_quant_cpu(new_compressed_kv)
-                )
-            else:
-                new_compressed_kv_fp8, new_compressed_kv_scale = act_quant(
-                    new_compressed_kv
-                )
+            new_compressed_kv_fp8, new_compressed_kv_scale = act_quant(
+                new_compressed_kv
+            )
             token_to_kv_pool.set_index_k_scale_buffer(
                 layer_id=layer_id,
                 loc=self.forward_metadata.core_metadata.c4_out_loc,

--- a/python/sglang/srt/layers/moe/hash_topk.py
+++ b/python/sglang/srt/layers/moe/hash_topk.py
@@ -22,6 +22,7 @@ logger = logging.getLogger(__name__)
 _is_cpu = is_cpu()
 _is_cpu_amx_available = cpu_has_amx_support()
 
+
 class HashTopK(nn.Module):
     def __init__(
         self,
@@ -113,7 +114,9 @@ class HashTopK(nn.Module):
         if envs.SGLANG_OPT_USE_FUSED_HASH_TOPK.get():
             if _is_cpu and _is_cpu_amx_available:
                 # CPU SGL kernel path: tid2eid lookup done in Python, kernel does scoring + gather
-                tid2eid_for_tokens = self.tid2eid[input_ids]  # [num_tokens, routed_topk]
+                tid2eid_for_tokens = self.tid2eid[
+                    input_ids
+                ]  # [num_tokens, routed_topk]
                 topk_weights, topk_ids = torch.ops.sgl_kernel.hash_topk_cpu(
                     router_logits,
                     tid2eid_for_tokens,

--- a/python/sglang/srt/layers/moe/hash_topk.py
+++ b/python/sglang/srt/layers/moe/hash_topk.py
@@ -15,10 +15,12 @@ from sglang.srt.layers.moe.topk import (
     StandardTopKOutput,
     _mask_topk_ids_padded_region,
 )
-from sglang.srt.utils import is_hip
+from sglang.srt.utils import cpu_has_amx_support, is_cpu, is_hip
 
 logger = logging.getLogger(__name__)
 
+_is_cpu = is_cpu()
+_is_cpu_amx_available = cpu_has_amx_support()
 
 class HashTopK(nn.Module):
     def __init__(
@@ -109,16 +111,29 @@ class HashTopK(nn.Module):
         ), f"{input_ids.shape=} {hidden_states.shape=} {router_logits.shape=}"
 
         if envs.SGLANG_OPT_USE_FUSED_HASH_TOPK.get():
-            from sglang.jit_kernel.deepseek_v4 import hash_topk
+            if _is_cpu and _is_cpu_amx_available:
+                # CPU SGL kernel path: tid2eid lookup done in Python, kernel does scoring + gather
+                tid2eid_for_tokens = self.tid2eid[input_ids]  # [num_tokens, routed_topk]
+                topk_weights, topk_ids = torch.ops.sgl_kernel.hash_topk_cpu(
+                    router_logits,
+                    tid2eid_for_tokens,
+                    self.topk,
+                    self.score_func,
+                    self.num_fused_shared_experts,
+                    self.num_experts,
+                    self.routed_scaling_factor,
+                )
+            else:
+                from sglang.jit_kernel.deepseek_v4 import hash_topk
 
-            topk_weights, topk_ids = hash_topk(
-                router_logits=router_logits,
-                input_ids=input_ids,
-                tid2eid=self.tid2eid,
-                num_fused_shared_experts=self.num_fused_shared_experts,
-                routed_scaling_factor=self.routed_scaling_factor,
-                scoring_func=self.score_func,
-            )
+                topk_weights, topk_ids = hash_topk(
+                    router_logits=router_logits,
+                    input_ids=input_ids,
+                    tid2eid=self.tid2eid,
+                    num_fused_shared_experts=self.num_fused_shared_experts,
+                    routed_scaling_factor=self.routed_scaling_factor,
+                    scoring_func=self.score_func,
+                )
         else:
             topk_weights, topk_ids = self._forward_torch(router_logits, input_ids)
 

--- a/python/sglang/srt/layers/moe/topk.py
+++ b/python/sglang/srt/layers/moe/topk.py
@@ -1107,6 +1107,35 @@ def biased_grouped_topk_cpu(
     )
 
 
+def biased_topk_cpu(
+    hidden_states: torch.Tensor,
+    gating_output: torch.Tensor,
+    correction_bias: torch.Tensor,
+    topk: int,
+    renormalize: bool,
+    scoring_func: str = "sigmoid",
+    num_fused_shared_experts: int = 0,
+    routed_scaling_factor: Optional[float] = None,
+    num_token_non_padded: Optional[torch.Tensor] = None,
+    expert_location_dispatch_info: Optional[ExpertLocationDispatchInfo] = None,
+    apply_routed_scaling_factor_on_output: Optional[bool] = False,
+):
+    topk_weights, topk_ids = torch.ops.sgl_kernel.biased_topk_cpu(
+        hidden_states,
+        gating_output,
+        correction_bias,
+        topk,
+        renormalize,
+        scoring_func,
+        num_fused_shared_experts,
+        routed_scaling_factor,
+        apply_routed_scaling_factor_on_output or False,
+    )
+    topk_ids = topk_ids_logical_to_physical(topk_ids, expert_location_dispatch_info)
+    _mask_topk_ids_padded_region(topk_ids, num_token_non_padded)
+    return topk_weights, topk_ids
+
+
 if _is_cpu and _is_cpu_amx_available:
     biased_grouped_topk = biased_grouped_topk_cpu
     grouped_topk = grouped_topk_cpu
@@ -1314,25 +1343,40 @@ def select_experts(
     elif custom_routing_function is None:
         assert not apply_routed_scaling_factor_on_output, "Not implemented"
         if scoring_func == "sqrtsoftplus":
-            _biased_topk = (
-                biased_topk_jit_kernel_impl
-                if envs.SGLANG_OPT_USE_JIT_KERNEL_FUSED_TOPK.get()
-                else biased_topk_impl
-            )
+            if _is_cpu and _is_cpu_amx_available:
+                topk_weights, topk_ids = biased_topk_cpu(
+                    hidden_states=hidden_states,
+                    gating_output=router_logits,
+                    correction_bias=correction_bias,
+                    topk=top_k,
+                    renormalize=renormalize,
+                    scoring_func=scoring_func,
+                    num_fused_shared_experts=num_fused_shared_experts,
+                    routed_scaling_factor=routed_scaling_factor,
+                    num_token_non_padded=num_token_non_padded,
+                    expert_location_dispatch_info=expert_location_dispatch_info,
+                    apply_routed_scaling_factor_on_output=apply_routed_scaling_factor_on_output,
+                )
+            else:
+                _biased_topk = (
+                    biased_topk_jit_kernel_impl
+                    if envs.SGLANG_OPT_USE_JIT_KERNEL_FUSED_TOPK.get()
+                    else biased_topk_impl
+                )
 
-            topk_weights, topk_ids = _biased_topk(
-                hidden_states=hidden_states,
-                gating_output=router_logits,
-                correction_bias=correction_bias,
-                topk=num_routed_topk if _use_aiter else top_k,
-                renormalize=renormalize,
-                scoring_func=scoring_func,
-                num_fused_shared_experts=num_fused_shared_experts,
-                routed_scaling_factor=routed_scaling_factor,
-                num_token_non_padded=num_token_non_padded,
-                expert_location_dispatch_info=expert_location_dispatch_info,
-                apply_routed_scaling_factor_on_output=apply_routed_scaling_factor_on_output,
-            )
+                topk_weights, topk_ids = _biased_topk(
+                    hidden_states=hidden_states,
+                    gating_output=router_logits,
+                    correction_bias=correction_bias,
+                    topk=num_routed_topk if _use_aiter else top_k,
+                    renormalize=renormalize,
+                    scoring_func=scoring_func,
+                    num_fused_shared_experts=num_fused_shared_experts,
+                    routed_scaling_factor=routed_scaling_factor,
+                    num_token_non_padded=num_token_non_padded,
+                    expert_location_dispatch_info=expert_location_dispatch_info,
+                    apply_routed_scaling_factor_on_output=apply_routed_scaling_factor_on_output,
+                )
         elif (
             get_moe_runner_backend().is_flashinfer_trtllm_routed()
             and scoring_func == "softmax"

--- a/python/sglang/srt/mem_cache/deepseek_v4_compress_state.py
+++ b/python/sglang/srt/mem_cache/deepseek_v4_compress_state.py
@@ -9,8 +9,11 @@ from sglang.srt.constants import GPU_MEMORY_TYPE_KV_CACHE
 from sglang.srt.environ import envs
 from sglang.srt.mem_cache.utils import maybe_init_custom_mem_pool
 from sglang.srt.utils.torch_memory_saver_adapter import TorchMemorySaverAdapter
+from sglang.srt.utils import cpu_has_amx_support, is_cpu
 
 
+_is_cpu = is_cpu()
+_cpu_amx = cpu_has_amx_support()
 @dataclasses.dataclass
 class KVAndScore:
     kv_score: torch.Tensor
@@ -105,7 +108,7 @@ class DeepSeekV4CompressState:
             self.kv_score_state = torch.empty(state_shape, dtype=dtype, device=device)
 
     def get_state(self):
-        if envs.SGLANG_CPU_USE_COMPRESS_SEPARATE.get():
+        if envs.SGLANG_CPU_USE_COMPRESS_SEPARATE.get() or (_is_cpu and _cpu_amx):
             half_dim = self.head_dim * (1 + self.overlap)
             return KVAndScoreSeparate(
                 kv=self.kv_score_state[..., :half_dim],

--- a/python/sglang/srt/mem_cache/deepseek_v4_compress_state.py
+++ b/python/sglang/srt/mem_cache/deepseek_v4_compress_state.py
@@ -8,12 +8,13 @@ import torch
 from sglang.srt.constants import GPU_MEMORY_TYPE_KV_CACHE
 from sglang.srt.environ import envs
 from sglang.srt.mem_cache.utils import maybe_init_custom_mem_pool
-from sglang.srt.utils.torch_memory_saver_adapter import TorchMemorySaverAdapter
 from sglang.srt.utils import cpu_has_amx_support, is_cpu
-
+from sglang.srt.utils.torch_memory_saver_adapter import TorchMemorySaverAdapter
 
 _is_cpu = is_cpu()
 _cpu_amx = cpu_has_amx_support()
+
+
 @dataclasses.dataclass
 class KVAndScore:
     kv_score: torch.Tensor

--- a/python/sglang/srt/mem_cache/deepseek_v4_memory_pool.py
+++ b/python/sglang/srt/mem_cache/deepseek_v4_memory_pool.py
@@ -23,10 +23,12 @@ from sglang.srt.mem_cache.deepseek_v4_compress_state import (
 )
 from sglang.srt.mem_cache.memory_pool import KVCache
 from sglang.srt.server_args import get_global_server_args
-from sglang.srt.utils import ceil_div
+from sglang.srt.utils import ceil_div, cpu_has_amx_support, is_cpu
 
 logger = logging.getLogger(__name__)
 
+_is_cpu = is_cpu()
+_cpu_amx = cpu_has_amx_support()
 ONLINE_C128 = envs.SGLANG_OPT_USE_ONLINE_COMPRESS.get()
 
 
@@ -471,7 +473,7 @@ class DeepSeekV4TokenToKVPool(BaseSWAKVPool):
 
         # Mutually exclusive: paged ring pools (radix path) vs. non-paged
         # per-request states used by the SGLANG_CPU_USE_COMPRESS_SEPARATE=1
-        if not envs.SGLANG_CPU_USE_COMPRESS_SEPARATE.get():
+        if not envs.SGLANG_CPU_USE_COMPRESS_SEPARATE.get() and not (_is_cpu and _cpu_amx):
             self._init_paged_compress_states(enable_memory_saver)
             self.compress_states: List[Optional[DeepSeekV4CompressState]] = []
             self.indexer_compress_states: List[Optional[DeepSeekV4CompressState]] = []
@@ -659,7 +661,7 @@ class DeepSeekV4TokenToKVPool(BaseSWAKVPool):
     def get_attention_compress_states(
         self, layer_id: int
     ) -> Union[CompressStatePool, KVAndScore, KVAndScoreSeparate]:
-        if not envs.SGLANG_CPU_USE_COMPRESS_SEPARATE.get():
+        if not envs.SGLANG_CPU_USE_COMPRESS_SEPARATE.get() and not (_is_cpu and _cpu_amx):
             compress_state_pool = self.compress_state_pools[layer_id]
             assert (
                 compress_state_pool is not None
@@ -672,7 +674,7 @@ class DeepSeekV4TokenToKVPool(BaseSWAKVPool):
     def get_indexer_compress_states(
         self, layer_id: int
     ) -> Union[CompressStatePool, KVAndScore, KVAndScoreSeparate]:
-        if not envs.SGLANG_CPU_USE_COMPRESS_SEPARATE.get():
+        if not envs.SGLANG_CPU_USE_COMPRESS_SEPARATE.get() and not (_is_cpu and _cpu_amx):
             indexer_compress_state_pool = self.indexer_compress_state_pools[layer_id]
             assert (
                 indexer_compress_state_pool is not None

--- a/python/sglang/srt/mem_cache/deepseek_v4_memory_pool.py
+++ b/python/sglang/srt/mem_cache/deepseek_v4_memory_pool.py
@@ -473,7 +473,9 @@ class DeepSeekV4TokenToKVPool(BaseSWAKVPool):
 
         # Mutually exclusive: paged ring pools (radix path) vs. non-paged
         # per-request states used by the SGLANG_CPU_USE_COMPRESS_SEPARATE=1
-        if not envs.SGLANG_CPU_USE_COMPRESS_SEPARATE.get() and not (_is_cpu and _cpu_amx):
+        if not envs.SGLANG_CPU_USE_COMPRESS_SEPARATE.get() and not (
+            _is_cpu and _cpu_amx
+        ):
             self._init_paged_compress_states(enable_memory_saver)
             self.compress_states: List[Optional[DeepSeekV4CompressState]] = []
             self.indexer_compress_states: List[Optional[DeepSeekV4CompressState]] = []
@@ -661,7 +663,9 @@ class DeepSeekV4TokenToKVPool(BaseSWAKVPool):
     def get_attention_compress_states(
         self, layer_id: int
     ) -> Union[CompressStatePool, KVAndScore, KVAndScoreSeparate]:
-        if not envs.SGLANG_CPU_USE_COMPRESS_SEPARATE.get() and not (_is_cpu and _cpu_amx):
+        if not envs.SGLANG_CPU_USE_COMPRESS_SEPARATE.get() and not (
+            _is_cpu and _cpu_amx
+        ):
             compress_state_pool = self.compress_state_pools[layer_id]
             assert (
                 compress_state_pool is not None
@@ -674,7 +678,9 @@ class DeepSeekV4TokenToKVPool(BaseSWAKVPool):
     def get_indexer_compress_states(
         self, layer_id: int
     ) -> Union[CompressStatePool, KVAndScore, KVAndScoreSeparate]:
-        if not envs.SGLANG_CPU_USE_COMPRESS_SEPARATE.get() and not (_is_cpu and _cpu_amx):
+        if not envs.SGLANG_CPU_USE_COMPRESS_SEPARATE.get() and not (
+            _is_cpu and _cpu_amx
+        ):
             indexer_compress_state_pool = self.indexer_compress_state_pools[layer_id]
             assert (
                 indexer_compress_state_pool is not None

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -3249,7 +3249,8 @@ class ModelRunner(ModelRunnerKVCacheMixin):
         # Step span
         step_span_ctx = (
             torch.profiler.record_function(_build_step_span_name(forward_batch))
-            if torch.autograd._profiler_enabled() and not (_is_cpu and _is_cpu_amx_available)
+            if torch.autograd._profiler_enabled()
+            and not (_is_cpu and _is_cpu_amx_available)
             else contextlib.nullcontext()
         )
         with (

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -192,6 +192,7 @@ from sglang.srt.utils import (
     get_bool_env_var,
     get_cpu_ids_by_node,
     init_custom_process_group,
+    is_cpu,
     is_hip,
     is_host_cpu_arm64,
     is_npu,
@@ -222,6 +223,7 @@ from sglang.srt.weight_sync.tensor_bucket import (
     FlattenedTensorMetadata,
 )
 
+_is_cpu = is_cpu()
 _is_hip = is_hip()
 _is_npu = is_npu()
 _is_cpu_amx_available = cpu_has_amx_support()
@@ -3247,7 +3249,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
         # Step span
         step_span_ctx = (
             torch.profiler.record_function(_build_step_span_name(forward_batch))
-            if torch.autograd._profiler_enabled()
+            if torch.autograd._profiler_enabled() and not (_is_cpu and _is_cpu_amx_available)
             else contextlib.nullcontext()
         )
         with (

--- a/python/sglang/srt/models/deepseek_v4.py
+++ b/python/sglang/srt/models/deepseek_v4.py
@@ -863,11 +863,6 @@ class DeepseekV4DecoderLayer(nn.Module):
                 (0, self.hc_mult, x.shape[-1]), dtype=x.dtype, device=x.device
             )
 
-        if envs.SGLANG_OPT_USE_TILELANG_MHC_POST.get():
-            from sglang.srt.layers.mhc import mhc_post
-
-            return mhc_post(x, residual, post, comb)
-
         if _is_cpu and _cpu_amx:
             return torch.ops.sgl_kernel.hc_post_fused_cpu(
                 x,
@@ -875,6 +870,12 @@ class DeepseekV4DecoderLayer(nn.Module):
                 post,
                 comb,
             )
+
+        if envs.SGLANG_OPT_USE_TILELANG_MHC_POST.get():
+            from sglang.srt.layers.mhc import mhc_post
+
+            return mhc_post(x, residual, post, comb)
+
         assert residual.shape == (x.shape[0], self.hc_mult, x.shape[-1])
         assert post.shape == (x.shape[0], self.hc_mult)
         assert comb.shape == (x.shape[0], self.hc_mult, self.hc_mult)

--- a/python/sglang/srt/models/deepseek_v4.py
+++ b/python/sglang/srt/models/deepseek_v4.py
@@ -807,6 +807,18 @@ class DeepseekV4DecoderLayer(nn.Module):
             )
             return y, post.squeeze(-1), comb, norm is not None
 
+        if _is_cpu and _cpu_amx:
+            y, post, comb = torch.ops.sgl_kernel.hc_pre_fused_cpu(
+                x,
+                hc_fn,
+                hc_scale,
+                hc_base,
+                self.hc_mult,
+                self.hc_sinkhorn_iters,
+                self.rms_norm_eps,
+                self.hc_eps,
+            )
+            return y, post, comb, False
         if envs.SGLANG_OPT_DEEPGEMM_HC_PRENORM.get():
             import deep_gemm
 
@@ -822,20 +834,7 @@ class DeepseekV4DecoderLayer(nn.Module):
             rsqrt = torch.rsqrt(s_out / k + self.rms_norm_eps)
             mixes = (d_out * rsqrt.unsqueeze(1)).unsqueeze(1)
         else:
-            if _is_cpu and _cpu_amx:
-                y, post, comb = torch.ops.sgl_kernel.hc_pre_fused_cpu(
-                    x,
-                    hc_fn,
-                    hc_scale,
-                    hc_base,
-                    self.hc_mult,
-                    self.hc_sinkhorn_iters,
-                    self.rms_norm_eps,
-                    self.hc_eps,
-                )
-                return y, post, comb, False
-            else:
-                x_flat, mixes = hc_pre_torch_impl(x, hc_fn)
+            x_flat, mixes = hc_pre_torch_impl(x, hc_fn)
 
         from sglang.srt.layers.mhc import hc_split_sinkhorn
 

--- a/python/sglang/srt/models/deepseek_v4.py
+++ b/python/sglang/srt/models/deepseek_v4.py
@@ -785,6 +785,19 @@ class DeepseekV4DecoderLayer(nn.Module):
             )
             return y, post, comb, False
 
+        if _is_cpu and _cpu_amx:
+            y, post, comb = torch.ops.sgl_kernel.hc_pre_fused_cpu(
+                x,
+                hc_fn,
+                hc_scale,
+                hc_base,
+                self.hc_mult,
+                self.hc_sinkhorn_iters,
+                self.rms_norm_eps,
+                self.hc_eps,
+            )
+            return y, post, comb, False
+
         if envs.SGLANG_OPT_USE_TILELANG_MHC_PRE.get():
             from sglang.srt.layers.mhc import mhc_pre
 
@@ -807,18 +820,6 @@ class DeepseekV4DecoderLayer(nn.Module):
             )
             return y, post.squeeze(-1), comb, norm is not None
 
-        if _is_cpu and _cpu_amx:
-            y, post, comb = torch.ops.sgl_kernel.hc_pre_fused_cpu(
-                x,
-                hc_fn,
-                hc_scale,
-                hc_base,
-                self.hc_mult,
-                self.hc_sinkhorn_iters,
-                self.rms_norm_eps,
-                self.hc_eps,
-            )
-            return y, post, comb, False
         if envs.SGLANG_OPT_DEEPGEMM_HC_PRENORM.get():
             import deep_gemm
 

--- a/python/sglang/srt/models/deepseek_v4.py
+++ b/python/sglang/srt/models/deepseek_v4.py
@@ -404,6 +404,8 @@ class MQALayer(nn.Module):
         )
 
         self.overlap_store_cache = envs.SGLANG_OPT_USE_OVERLAP_STORE_CACHE.get()
+        if _is_cpu and _cpu_amx:
+            self.overlap_store_cache = False
         self.use_jit_norm = envs.SGLANG_OPT_USE_JIT_NORM.get()
 
     def _compute_q_a(


### PR DESCRIPTION
command line: `python -m sglang.bench_one_batch --model-path /localdisk/models/hub/ds-v4-flash/ --trust-remote-code --tp 6 --attention-backend dsv4 --page-size 256 --disable-shared-experts-fusion --disable-cuda-graph --tool-call-parser deepseekv4 --reasoning-parser deepseek-v4 --input-len 1024 --output-len 1024 --batch-size 1 --profile`
performance:
<img width="883" height="1600" alt="image" src="https://github.com/user-attachments/assets/46050439-5289-4aa7-87ce-b19b14d28daf" />
<img width="883" height="1503" alt="image" src="https://github.com/user-attachments/assets/89f9c312-e3bc-46e4-a316-4d9eb0d0a256" />

Accuracy:
<img width="3019" height="220" alt="image" src="https://github.com/user-attachments/assets/c120a648-68c5-4157-b3e3-8150ea0d51e3" />


